### PR TITLE
fixed undefined variable $siteimprove_nonce

### DIFF
--- a/siteimprove/admin/partials/class-siteimprove-admin-settings.php
+++ b/siteimprove/admin/partials/class-siteimprove-admin-settings.php
@@ -46,7 +46,7 @@ class Siteimprove_Admin_Settings {
 			'siteimprove_token'
 		);
 
-		$this->siteimprove_nonce = wp_create_nonce('siteimprove_nonce');
+		$this->siteimprove_nonce = wp_create_nonce( 'siteimprove_nonce' );
 	}
 
 	/**
@@ -55,8 +55,8 @@ class Siteimprove_Admin_Settings {
 	public function register_menu() {
 		// Add top level menu page.
 		add_menu_page(
-			__('Siteimprove Plugin'),
-			__('Siteimprove'),
+			__( 'Siteimprove Plugin' ),
+			__( 'Siteimprove' ),
 			'manage_options',
 			'siteimprove',
 			'Siteimprove_Admin_Settings::siteimprove_settings_form'
@@ -75,9 +75,9 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_token_field( $args ) { ?>
 
 		<input type="text" id="siteimprove_token_field" name="siteimprove_token" value="<?php echo esc_attr( get_option( 'siteimprove_token' ) ); ?>" maxlength="50" size="50" />
-        <input class="button" id="siteimprove_token_request" type="button" value="<?php echo esc_attr( __( 'Request new token', 'siteimprove' ) ); ?>" />
+		<input class="button" id="siteimprove_token_request" type="button" value="<?php echo esc_attr( __( 'Request new token', 'siteimprove' ) ); ?>" />
 
-        <?php
+		<?php
 	}
 
 	/**
@@ -95,18 +95,18 @@ class Siteimprove_Admin_Settings {
 		}
 		settings_errors( 'siteimprove_messages' );
 		?>
-        <div class="wrap">
-            <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
-            <form action="options.php" method="post">
+		<div class="wrap">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+			<form action="options.php" method="post">
 				<?php
 				// Display settings fields.
 				settings_fields( 'siteimprove' );
 				do_settings_sections( 'siteimprove' );
 				// Submit button.
-				submit_button( __('Save Settings') );
+				submit_button( __( 'Save Settings' ) );
 				?>
-            </form>
-        </div>
+			</form>
+		</div>
 		<?php
 	}
 

--- a/siteimprove/admin/partials/class-siteimprove-admin-settings.php
+++ b/siteimprove/admin/partials/class-siteimprove-admin-settings.php
@@ -90,7 +90,7 @@ class Siteimprove_Admin_Settings {
 		}
 
 		// Show success message.
-		if ( wp_verify_nonce( $siteimprove_nonce, 'siteimprove_nonce' ) && isset( $_GET['settings-updated'] ) ) {
+		if ( filter_input( INPUT_GET, 'settings-updated' ) ) {
 			add_settings_error( 'siteimprove_messages', 'siteimprove_message', __( 'Settings Saved', 'siteimprove' ), 'updated' );
 		}
 		settings_errors( 'siteimprove_messages' );


### PR DESCRIPTION
@krusoleo @kvhsiteimprove  there was an debug error on setting page.  because of undefined variable.

![Screen Shot 2020-09-02 at 4 30 50 PM](https://user-images.githubusercontent.com/25645440/92033449-af687a00-ed39-11ea-8de3-9a64e9ca56ee.png)

It uses WordPress's native settings API, so there's no need to check for the nonce there. 
I believe developer added the nonce to avoid WPCS errors. But we can fix it something like this

https://github.com/Siteimprove/CMS-plugin-Wordpress/pull/2/commits/15f82f46c894cbc097b6f3b460df13804545f7cb#diff-26cce9fe112352c997c11b2ea5de9c8bL92-L94

fixed here https://github.com/Siteimprove/CMS-plugin-Wordpress/pull/2