### PR TITLE
INT-2694 CMS-Wordpress-Plugin including admin bar and smallbox in the DOM harvesting

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,9 +11,9 @@
 		<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment"/>
 	</rule>
 	
-	<!--For Windows users that may have problems with EOL-->
-	<!-- <rule ref="Generic.Files.LineEndings">
+	<!--For Windows users that may have problems with EOL. If you are not using windows please coment the code bellow-->
+	<rule ref="Generic.Files.LineEndings">
         <exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
-    </rule> -->
+    </rule>
 
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,7 +11,7 @@
 		<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment"/>
 	</rule>
 	
-	<!--For Windows users that may have problems with EOL. If you are not using windows please coment the code bellow-->
+	<!-- For Windows users that may have problems with EOL. If you are not using Windows please comment out the code below -->
 	<rule ref="Generic.Files.LineEndings">
         <exclude name="Generic.Files.LineEndings.InvalidEOLChar"/>
     </rule>

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -46,22 +46,22 @@
         newDiv.setAttribute("id","div_iframe"); 
         document.body.appendChild(newDiv);
         newDiv.innerHTML = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";
-      	
-      	const promise = new Promise(function (resolve, reject) {
+
+        const promise = new Promise(function (resolve, reject) {
           const iframe = document.getElementById("domIframe");
-      		iframe.addEventListener(
-      			"load",
-      			() => {
+          iframe.addEventListener(
+            "load",
+            () => {
                 const newDocument = iframe.contentWindow.document.cloneNode(true);
                 document.body.removeChild(newDiv);
                 resolve(newDocument);
             },
-      			{ once: true }
-      		);
-      	});
+            { once: true }
+          );
+        });
       
-      	const documentReturned = await promise;
-      	return [
+        const documentReturned = await promise;
+        return [
           documentReturned, 
           () => { 
             $(".si-overlay").remove();

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -45,8 +45,8 @@
         const newDiv = document.createElement("div");
         newDiv.setAttribute("id","div_iframe"); 
         document.body.appendChild(newDiv);
-        let	string_test = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";
-        document.getElementById("div_iframe").innerHTML = string_test.replace(/&amp;/g , "&");
+        let	iframeString = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";
+        document.getElementById("div_iframe").innerHTML = iframeString.replace(/&amp;/g , "&");
       	
       	const promise = new Promise(function (resolve, reject) {
           const iframe = document.getElementById("domIframe");
@@ -55,8 +55,8 @@
       			() => { 
               const newDocument = iframe.contentWindow.document.cloneNode(true);
               document.getElementById("div_iframe").innerHTML = "";
-              document.body.removeChild(newDiv); 
-              resolve(newDocument); 
+              document.body.removeChild(newDiv);
+              resolve(newDocument);
             },
       			{ once: true }
       		);

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -39,16 +39,16 @@
       this.common();
     },
     common: function (url) {
-      var _si = window._si || [];  
+      const _si = window._si || [];  
     
-      var getDomCallback = async function (document) {
+      const getDomCallback = async function () {
         const newDiv = document.createElement("div");
         newDiv.setAttribute("id","div_iframe"); 
         document.body.appendChild(newDiv);
         let	string_test = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";
         document.getElementById("div_iframe").innerHTML = string_test.replace(/&amp;/g , "&");
       	
-      	var promise = new Promise(function (resolve, reject) {
+      	const promise = new Promise(function (resolve, reject) {
           const iframe = document.getElementById("domIframe");
       		iframe.addEventListener(
       			"load",
@@ -62,16 +62,16 @@
       		);
       	});
       
-      	var document = await promise;
+      	const documentReturned = await promise;
       	return [
-          document, 
+          documentReturned, 
           () => { 
             $(".si-overlay").remove();
           }
         ];
       };
 
-      _si.push(['registerPrepublishCallback', getDomCallback(document), this.token]);
+      _si.push(['registerPrepublishCallback', getDomCallback, this.token]);
 
       if (this.method == "contentcheck-flat-dom") {
         _si.push([

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -102,6 +102,11 @@
           } else {
             $element.html("<span class='si-highlight'>" + text + "</span>");
           }
+          
+          //Scroll to the target element
+          $([document.documentElement, document.body]).animate({
+            scrollTop: $(".si-highlight").offset().top
+          }, 1500);
         });
       }]);
 

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -105,7 +105,7 @@
           
           //Scroll to the target element
           $([document.documentElement, document.body]).animate({
-            scrollTop: $(".si-highlight").offset().top
+            scrollTop: $(".si-highlight").offset().top - $("#wpadminbar").height()
           }, 1500);
         });
       }]);

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -85,13 +85,13 @@
 
       _si.push(['onHighlight', function(highlightInfo) {
         // Remove highlight tag wrapper
-        $(".si-highlight").contents().unwrap();
+        $( ".si-highlight" ).contents().unwrap();
         // Create an span tag for every highlight
-        $.each(highlightInfo.highlights, function(index, highlight) {
+        $.each( highlightInfo.highlights, function( index, highlight ) {
           var $element = $(highlight.selector);
           var text = $element.text();
           
-          if (highlight.offset) {
+          if ( highlight.offset ) {
             var start = highlight.offset.start;
             var length = highlight.offset.length;
             
@@ -101,7 +101,13 @@
             
             $element.html(before + "<span class='si-highlight'>" + highlighted + "</span>" + after);
           } else {
-            $element.html("<span class='si-highlight'>" + text + "</span>");
+            //Dealing in a different way if the element or it's children came as an image.
+            if( $element.is('img') || $( $element[0] ).children().is( "img" ) ){
+              //Adding an inline padding was needed to put in evidence the div borders
+              $( $element[0] ).wrap( "<div class='si-highlight' style='padding: 5px;'></div>" );
+            }else{
+              $element.html( "<span class='si-highlight'>" + text + "</span>" );
+            }
           }
           
           //Scroll to the target element

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -45,15 +45,14 @@
         const newDiv = document.createElement("div");
         newDiv.setAttribute("id","div_iframe"); 
         document.body.appendChild(newDiv);
-        document.getElementById("div_iframe").innerHTML = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";;
+        newDiv.innerHTML = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";
       	
       	const promise = new Promise(function (resolve, reject) {
           const iframe = document.getElementById("domIframe");
       		iframe.addEventListener(
       			"load",
-      			() => { 
+      			() => {
               const newDocument = iframe.contentWindow.document.cloneNode(true);
-              document.getElementById("div_iframe").innerHTML = "";
               document.body.removeChild(newDiv);
               resolve(newDocument);
             },

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -16,19 +16,19 @@
       this.url = url;
       this.token = token;
       this.method = "domain";
-      this.common();
+      this.common(url);
     },
     recheck: function (url, token) {
       this.url = url;
       this.token = token;
       this.method = "recheck";
-      this.common();
+      this.common(url);
     },
     recrawl: function (url, token) {
       this.url = url;
       this.token = token;
       this.method = "recrawl";
-      this.common();
+      this.common(url);
     },
     contentcheck_flatdom: function (domReference, url, token, callback) {
       this.url = url;
@@ -36,7 +36,7 @@
       this.domReference = domReference;
       this.method = "contentcheck-flat-dom";
       this.callback = callback;
-      this.common();
+      this.common(url);
     },
     common: function (url) {
       const _si = window._si || [];  

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -40,26 +40,38 @@
     },
     common: function (url) {
       var _si = window._si || [];  
-
-      var getDomCallback = async function () {
-      	var pageWindow = window.open(
-      		url,
-      		"Page Preview",
-      		"width=400,height=500"
-      	);
+    
+      var getDomCallback = async function (document) {
+        const newDiv = document.createElement("div");
+        newDiv.setAttribute("id","div_iframe"); 
+        document.body.appendChild(newDiv);
+        let	string_test = "<iframe id='domIframe' src="+ url.concat("&hide_admin_bar=1") +" style='height:100vh; width:100%'></iframe>";
+        document.getElementById("div_iframe").innerHTML = string_test.replace(/&amp;/g , "&");
+      	
       	var promise = new Promise(function (resolve, reject) {
-      		pageWindow.addEventListener(
+          const iframe = document.getElementById("domIframe");
+      		iframe.addEventListener(
       			"load",
-      			() => { resolve(pageWindow.document); },
+      			() => { 
+              const newDocument = iframe.contentWindow.document.cloneNode(true);
+              document.getElementById("div_iframe").innerHTML = "";
+              document.body.removeChild(newDiv); 
+              resolve(newDocument); 
+            },
       			{ once: true }
       		);
       	});
       
       	var document = await promise;
-      	return [document, () => { pageWindow.close(); }];
+      	return [
+          document, 
+          () => { 
+            $(".si-overlay").remove();
+          }
+        ];
       };
 
-      _si.push(['registerPrepublishCallback', getDomCallback, this.token]);
+      _si.push(['registerPrepublishCallback', getDomCallback(document), this.token]);
 
       if (this.method == "contentcheck-flat-dom") {
         _si.push([

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -111,7 +111,7 @@
           }
           
           //Scroll to the target element
-          $([document.documentElement, document.body]).animate({
+          $([document.documentElement, document.body]).stop().animate({
             scrollTop: $(".si-highlight").offset().top - $("#wpadminbar").height()
           }, 1500);
         });

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -45,7 +45,7 @@
         const newDiv = document.createElement("div");
         newDiv.setAttribute("id","div_iframe"); 
         document.body.appendChild(newDiv);
-        let	string_test = "<iframe id='domIframe' src="+ url.concat("&hide_admin_bar=1") +" style='height:100vh; width:100%'></iframe>";
+        let	string_test = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";
         document.getElementById("div_iframe").innerHTML = string_test.replace(/&amp;/g , "&");
       	
       	var promise = new Promise(function (resolve, reject) {

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -45,8 +45,7 @@
         const newDiv = document.createElement("div");
         newDiv.setAttribute("id","div_iframe"); 
         document.body.appendChild(newDiv);
-        let	iframeString = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";
-        document.getElementById("div_iframe").innerHTML = iframeString.replace(/&amp;/g , "&");
+        document.getElementById("div_iframe").innerHTML = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";;
       	
       	const promise = new Promise(function (resolve, reject) {
           const iframe = document.getElementById("domIframe");

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -52,9 +52,9 @@
       		iframe.addEventListener(
       			"load",
       			() => {
-              const newDocument = iframe.contentWindow.document.cloneNode(true);
-              document.body.removeChild(newDiv);
-              resolve(newDocument);
+                const newDocument = iframe.contentWindow.document.cloneNode(true);
+                document.body.removeChild(newDiv);
+                resolve(newDocument);
             },
       			{ once: true }
       		);

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -45,6 +45,7 @@
         const newDiv = document.createElement("div");
         newDiv.setAttribute("id","div_iframe"); 
         document.body.appendChild(newDiv);
+        //Opens an alternative version of this page without wp injected content such as the wp-admin bar and smallbox plugin itself as this is for the DOM we send to Siteimprove
         newDiv.innerHTML = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";
 
         const promise = new Promise(function (resolve, reject) {

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -145,7 +145,7 @@ class Siteimprove {
 		$this->loader->add_action( 'siteimprove_before_settings_form', $plugin_admin, 'siteimprove_before_settings_form' );
 
 		// Siteimprove Actions.
-		if ( ! isset( $_GET['hide_admin_bar'] ) || '0' === $_GET['hide_admin_bar'] ) {
+		if ( ! isset( $_GET['si_preview'] ) || '0' === $_GET['si_preview'] ) {
 			$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
 			$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
 			$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -145,7 +145,7 @@ class Siteimprove {
 		$this->loader->add_action( 'siteimprove_before_settings_form', $plugin_admin, 'siteimprove_before_settings_form' );
 
 		// Siteimprove Actions.
-		if (!isset($_GET['hide_admin_bar']) || $_GET['hide_admin_bar'] == '0') {
+		if ( ! isset( $_GET['hide_admin_bar'] ) || '0' === $_GET['hide_admin_bar'] ) {
 			$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
 			$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
 			$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -145,14 +145,16 @@ class Siteimprove {
 		$this->loader->add_action( 'siteimprove_before_settings_form', $plugin_admin, 'siteimprove_before_settings_form' );
 
 		// Siteimprove Actions.
-		$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
-		$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
-		$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );
-		$this->loader->add_action( 'edit_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
-		$this->loader->add_action( 'create_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
-		$this->loader->add_action( 'transition_post_status', $plugin_admin, 'siteimprove_save_session_url_product', 10, 3 );
-		$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_wp_head' );
-		$this->loader->add_action( 'admin_bar_menu', $plugin_admin, 'add_prepublish_toolbar_item', 500, 1 );
+		if (!isset($_GET['hide_admin_bar']) || $_GET['hide_admin_bar'] == '0') {
+			$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
+			$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
+			$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );
+			$this->loader->add_action( 'edit_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
+			$this->loader->add_action( 'create_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
+			$this->loader->add_action( 'transition_post_status', $plugin_admin, 'siteimprove_save_session_url_product', 10, 3 );
+			$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_wp_head' );
+			$this->loader->add_action( 'admin_bar_menu', $plugin_admin, 'add_prepublish_toolbar_item', 500, 1 );
+		}
 	}
 
 	/**

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -25,12 +25,12 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 /**  Hide the WordPress admin bar when the `si_preview` parameter is present. */
-function custom_preview_si_preview() {
+function si_preview() {
 	if ( isset( $_GET['si_preview'] ) && '1' === $_GET['si_preview'] ) {
 		add_filter( 'show_admin_bar', '__return_false' );
 	}
 }
-add_action( 'parse_query', 'custom_preview_si_preview' );
+add_action( 'parse_query', 'si_preview' );
 
 /**
  * Include SiteimproveUtils class.

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -24,6 +24,14 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
+// Hide the WordPress admin bar when the `hide_admin_bar` parameter is present
+function custom_preview_hide_admin_bar() {
+    if (isset($_GET['hide_admin_bar']) && $_GET['hide_admin_bar'] == '1') {
+        add_filter('show_admin_bar', '__return_false');
+    }
+}
+add_action('parse_query', 'custom_preview_hide_admin_bar');
+
 /**
  * Include SiteimproveUtils class.
  */

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -24,13 +24,13 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-/**  Hide the WordPress admin bar when the `hide_admin_bar` parameter is present. */
-function custom_preview_hide_admin_bar() {
-	if ( isset( $_GET['hide_admin_bar'] ) && '1' === $_GET['hide_admin_bar'] ) {
+/**  Hide the WordPress admin bar when the `si_preview` parameter is present. */
+function custom_preview_si_preview() {
+	if ( isset( $_GET['si_preview'] ) && '1' === $_GET['si_preview'] ) {
 		add_filter( 'show_admin_bar', '__return_false' );
 	}
 }
-add_action( 'parse_query', 'custom_preview_hide_admin_bar' );
+add_action( 'parse_query', 'custom_preview_si_preview' );
 
 /**
  * Include SiteimproveUtils class.

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -24,13 +24,13 @@ if ( ! defined( 'WPINC' ) ) {
 	die;
 }
 
-// Hide the WordPress admin bar when the `hide_admin_bar` parameter is present
+/**  Hide the WordPress admin bar when the `hide_admin_bar` parameter is present. */
 function custom_preview_hide_admin_bar() {
-    if (isset($_GET['hide_admin_bar']) && $_GET['hide_admin_bar'] == '1') {
-        add_filter('show_admin_bar', '__return_false');
-    }
+	if ( isset( $_GET['hide_admin_bar'] ) && '1' === $_GET['hide_admin_bar'] ) {
+		add_filter( 'show_admin_bar', '__return_false' );
+	}
 }
-add_action('parse_query', 'custom_preview_hide_admin_bar');
+add_action( 'parse_query', 'custom_preview_hide_admin_bar' );
 
 /**
  * Include SiteimproveUtils class.


### PR DESCRIPTION
After some internal discussions the team decided that the best way of doing this correction was by opening an iframe instead of a new window. 

The iframe should have the same size of the original page to avoid problems with responsivity.

We also changed some WP methods to hide the admin bar and smallbox if the querystring parameter "hide_admin_bar=1" is added to the URL.

Note: At the code you'll also find the changes for highlighting and Public URL field. 