### PR TITLE
INS-759 As a developer I can use Wordpress for local development

### DIFF
--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -167,13 +167,13 @@ class Siteimprove_Admin {
 		$pattern = '/^[a-zA-Z_\d-]+.js/gm';
 
 		if ( preg_match( $pattern, $file_name ) ) {
-			$smallbox_path = Siteimprove::JS_LIBRARY_URL . $file_name;
+			$overlay_path = Siteimprove::JS_LIBRARY_URL . $file_name;
 		} else {
-			$smallbox_path = $file_name;
+			$overlay_path = $file_name;
 		}
 
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove.js', array( 'jquery' ), $this->version, false );
-		wp_enqueue_script( 'siteimprove_overlay', $smallbox_path, array(), $this->version, true );
+		wp_enqueue_script( 'siteimprove_overlay', $overlay_path, array(), $this->version, true );
 		$public_url = get_option( 'siteimprove_public_url' );
 
 		if ( ! empty( $public_url ) ) {

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -167,13 +167,13 @@ class Siteimprove_Admin {
 		$pattern = '/^[a-zA-Z_\d-]+.js/gm';
 
 		if ( preg_match( $pattern, $file_name ) ) {
-			$adjusted_name = Siteimprove::JS_LIBRARY_URL . $file_name;
+			$smallbox_path = Siteimprove::JS_LIBRARY_URL . $file_name;
 		} else {
-			$adjusted_name = $file_name;
+			$smallbox_path = $file_name;
 		}
 
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove.js', array( 'jquery' ), $this->version, false );
-		wp_enqueue_script( 'siteimprove_overlay', $adjusted_name, array(), $this->version, true );
+		wp_enqueue_script( 'siteimprove_overlay', $smallbox_path, array(), $this->version, true );
 		$public_url = get_option( 'siteimprove_public_url' );
 
 		if ( ! empty( $public_url ) ) {

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -163,8 +163,9 @@ class Siteimprove_Admin {
 	 * @return void
 	 */
 	private function siteimprove_add_js( $url, $type ) {
-		$file_name = get_option( 'siteimprove_overlayjs_file', 'overlay.js' );
-		$pattern = '/^[a-zA-Z_\d-]+.js/gm';
+		$file_name = get_option( 'siteimprove_overlayjs_file', 'overlay-v2-dev.js' );
+		$pattern = '/^[a-zA-Z_\d-]+.js/';
+		//$pattern = '/^(?:https?://)?[\w.-]+\.[a-zA-Z]{2,}(?:\.[a-zA-Z]{2})?/(?:(?:[\w/%-]+\.js)|(?:[\w/%-]+\?[\w=%&-]*\.js))$/gm';
 
 		if ( preg_match( $pattern, $file_name ) ) {
 			$overlay_path = Siteimprove::JS_LIBRARY_URL . $file_name;

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -163,8 +163,17 @@ class Siteimprove_Admin {
 	 * @return void
 	 */
 	private function siteimprove_add_js( $url, $type ) {
+		$file_name = get_option( 'siteimprove_overlayjs_file', 'overlay.js' );
+		$pattern = "/^[a-zA-Z_\d-]+.js/gm";
+
+		if( preg_match($pattern, $file_name) ){
+			$adjusted_name = Siteimprove::JS_LIBRARY_URL . $file_name;
+		} else {
+			$adjusted_name = $file_name;
+		}
+
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove.js', array( 'jquery' ), $this->version, false );
-		wp_enqueue_script( 'siteimprove_overlay', Siteimprove::JS_LIBRARY_URL . get_option( 'siteimprove_overlayjs_file', 'overlay.js' ), array(), $this->version, true );
+		wp_enqueue_script( 'siteimprove_overlay', $adjusted_name, array(), $this->version, true );
 		$public_url = get_option( 'siteimprove_public_url' );
 
 		if ( ! empty( $public_url ) ) {

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -165,7 +165,6 @@ class Siteimprove_Admin {
 	private function siteimprove_add_js( $url, $type ) {
 		$file_name = get_option( 'siteimprove_overlayjs_file', 'overlay-v2-dev.js' );
 		$pattern = '/^[a-zA-Z_\d-]+.js/';
-		//$pattern = '/^(?:https?://)?[\w.-]+\.[a-zA-Z]{2,}(?:\.[a-zA-Z]{2})?/(?:(?:[\w/%-]+\.js)|(?:[\w/%-]+\?[\w=%&-]*\.js))$/gm';
 
 		if ( preg_match( $pattern, $file_name ) ) {
 			$overlay_path = Siteimprove::JS_LIBRARY_URL . $file_name;

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -164,9 +164,9 @@ class Siteimprove_Admin {
 	 */
 	private function siteimprove_add_js( $url, $type ) {
 		$file_name = get_option( 'siteimprove_overlayjs_file', 'overlay.js' );
-		$pattern = "/^[a-zA-Z_\d-]+.js/gm";
+		$pattern = '/^[a-zA-Z_\d-]+.js/gm';
 
-		if( preg_match($pattern, $file_name) ){
+		if ( preg_match( $pattern, $file_name ) ) {
 			$adjusted_name = Siteimprove::JS_LIBRARY_URL . $file_name;
 		} else {
 			$adjusted_name = $file_name;


### PR DESCRIPTION
I did a small change where we get the file name/full path and if it match the regex pattern (just-file-name.js) the CDN path will be inserted before it. Otherwise, the code will get the full text from the input field.

* The CDN path came from the constant: Siteimprove::JS_LIBRARY_URL