### PR TITLE
INS-2753: After removing domain, Smallbox was not initialised anymore on settings/dashboard etc. non-content pages. Add it back with clear method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ This is the git repository for the official Siteimprove plugin for WordPress.
 
 The code on this repository has to match the WordPress Coding Standards in order to be maintainable and understandable in the future by anyone who contributes to the project.
 
-Every pull request will be checked against WPCS trough github actions.
+Every pull request will be checked against WPCS through GitHub Actions.
 
 ## Version History
+
+### 2.0.2
+* Added Calling "clear" on non-content pages in WordPress
+* Added Prepublish can now be started from a published page
 
 ### 2.0.1
 * Bugfix - Fixed checkbox for "Use latest experience" was not properly checked on by default

--- a/README.md
+++ b/README.md
@@ -9,26 +9,26 @@ Every pull request will be checked against WPCS through GitHub Actions.
 ## Version History
 
 ### 2.0.2
-* Added Calling "clear" on non-content pages in WordPress
-* Added Prepublish can now be started from a published page
+* Added - Calling "clear" on non-content pages in WordPress
+* Added - Prepublish can now be started from a published page
 
 ### 2.0.1
 * Bugfix - Fixed checkbox for "Use latest experience" was not properly checked on by default
 
 ### 2.0.0
-* Added support for new version
-* Added a checkbox to disable new version
-* Added Public URL field to the plugin
+* Added - Support for new version
+* Added - A checkbox to disable new version
+* Added - Public URL field to the plugin
 
 ### 1.3.1
 * Bugfix - Fixed Highlighting content issues for prepublish checks.
 
 ### 1.3.0
-* Added Prepublish feature to the plugin
-* Added configuration page to set up an API key and API username
+* Added - Prepublish feature to the plugin
+* Added - Configuration page to set up an API key and API username
 
 ### 1.2.2
-* Bufgix - added CSS naming prefixes to avoid collision with other plugins
+* Bugfix - added CSS naming prefixes to avoid collision with other plugins
 
 ### 1.2.1
 * Bugfix - added check on nonce variable

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -90,7 +90,7 @@ class Siteimprove_Admin {
 		$prepublish_allowed = intval( get_option( 'siteimprove_prepublish_allowed', 0 ) );
 		$prepublish_enabled = intval( get_option( 'siteimprove_prepublish_enabled', 0 ) );
 
-		if ( $wp_query->is_preview() && 1 === $prepublish_allowed && 1 === $prepublish_enabled ) {
+		if ( ($wp_query->is_preview() || $wp_query->is_singular()) && 1 === $prepublish_allowed && 1 === $prepublish_enabled ) {
 			wp_enqueue_style( 'siteimprove_preview_css', plugin_dir_url( __FILE__ ) . 'css/siteimprove-preview.css', array(), $this->version, 'all' );
 		}
 	}
@@ -396,7 +396,7 @@ class Siteimprove_Admin {
 		$prepublish_allowed = intval( get_option( 'siteimprove_prepublish_allowed', 0 ) );
 		$prepublish_enabled = intval( get_option( 'siteimprove_prepublish_enabled', 0 ) );
 
-		if ( is_preview() && 1 === $prepublish_allowed && 1 === $prepublish_enabled ) {
+		if ( (is_preview() || is_singular()) && 1 === $prepublish_allowed && 1 === $prepublish_enabled ) {
 			$prepublish_button = '<svg xmlns="http://www.w3.org/2000/svg" height="28px" width="28px" viewBox="0 0 24 24" focusable="false" aria-hidden="true" fill="currentColor"><path fill="#141155" d="M12.015625.113281C5.433594.113281.113281 5.433594.113281 12.015625c0 6.578125 5.320313 11.886719 11.902344 11.886719 6.578125 0 11.886719-5.324219 11.886719-11.886719 0-6.566406-5.324219-11.902344-11.886719-11.902344Zm0 0"></path><path fill="#fff" d="m6.097656 14.796875 1.695313-1.003906c.367187.945312 1.074219 1.539062 2.328125 1.539062 1.257812 0 1.625-.507812 1.625-1.074219 0-.746093-.679688-1.042968-2.1875-1.480468-1.539063-.4375-3.050782-1.074219-3.050782-3.007813 0-1.933593 1.609376-2.992187 3.332032-2.992187s2.9375.847656 3.613281 2.257812l-1.664063.960938c-.367187-.777344-.917968-1.300782-1.949218-1.300782-.832032 0-1.328125.4375-1.328125 1.019532 0 .621094.382812.945312 1.921875 1.410156 1.609375.523438 3.316406 1.058594 3.316406 3.121094 0 1.890625-1.523438 3.046875-3.671875 3.046875-2.058594.015625-3.441406-.972657-3.980469-2.496094m8.667969-6.917969c0-.621094.507813-1.160156 1.144531-1.160156.636719 0 1.15625.539062 1.15625 1.160156 0 .621094-.507812 1.140625-1.15625 1.140625-.648437 0-1.144531-.519531-1.144531-1.140625m.214844 1.988282h1.863281v7.230468h-1.863281Zm0 0"></path></svg>';
 			$admin_bar->add_menu(
 				array(

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -90,7 +90,7 @@ class Siteimprove_Admin {
 		$prepublish_allowed = intval( get_option( 'siteimprove_prepublish_allowed', 0 ) );
 		$prepublish_enabled = intval( get_option( 'siteimprove_prepublish_enabled', 0 ) );
 
-		if ( ($wp_query->is_preview() || $wp_query->is_singular()) && 1 === $prepublish_allowed && 1 === $prepublish_enabled ) {
+		if ( ( $wp_query->is_preview() || $wp_query->is_singular() ) && 1 === $prepublish_allowed && 1 === $prepublish_enabled ) {
 			wp_enqueue_style( 'siteimprove_preview_css', plugin_dir_url( __FILE__ ) . 'css/siteimprove-preview.css', array(), $this->version, 'all' );
 		}
 	}
@@ -396,7 +396,7 @@ class Siteimprove_Admin {
 		$prepublish_allowed = intval( get_option( 'siteimprove_prepublish_allowed', 0 ) );
 		$prepublish_enabled = intval( get_option( 'siteimprove_prepublish_enabled', 0 ) );
 
-		if ( (is_preview() || is_singular()) && 1 === $prepublish_allowed && 1 === $prepublish_enabled ) {
+		if ( ( is_preview() || is_singular() ) && 1 === $prepublish_allowed && 1 === $prepublish_enabled ) {
 			$prepublish_button = '<svg xmlns="http://www.w3.org/2000/svg" height="28px" width="28px" viewBox="0 0 24 24" focusable="false" aria-hidden="true" fill="currentColor"><path fill="#141155" d="M12.015625.113281C5.433594.113281.113281 5.433594.113281 12.015625c0 6.578125 5.320313 11.886719 11.902344 11.886719 6.578125 0 11.886719-5.324219 11.886719-11.886719 0-6.566406-5.324219-11.902344-11.886719-11.902344Zm0 0"></path><path fill="#fff" d="m6.097656 14.796875 1.695313-1.003906c.367187.945312 1.074219 1.539062 2.328125 1.539062 1.257812 0 1.625-.507812 1.625-1.074219 0-.746093-.679688-1.042968-2.1875-1.480468-1.539063-.4375-3.050782-1.074219-3.050782-3.007813 0-1.933593 1.609376-2.992187 3.332032-2.992187s2.9375.847656 3.613281 2.257812l-1.664063.960938c-.367187-.777344-.917968-1.300782-1.949218-1.300782-.832032 0-1.328125.4375-1.328125 1.019532 0 .621094.382812.945312 1.921875 1.410156 1.609375.523438 3.316406 1.058594 3.316406 3.121094 0 1.890625-1.523438 3.046875-3.671875 3.046875-2.058594.015625-3.441406-.972657-3.980469-2.496094m8.667969-6.917969c0-.621094.507813-1.160156 1.144531-1.160156.636719 0 1.15625.539062 1.15625 1.160156 0 .621094-.507812 1.140625-1.15625 1.140625-.648437 0-1.144531-.519531-1.144531-1.140625m.214844 1.988282h1.863281v7.230468h-1.863281Zm0 0"></path></svg>';
 			$admin_bar->add_menu(
 				array(

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -190,14 +190,14 @@ class Siteimprove_Admin {
 			$url        = "$public_url$parsed_url[path]" . ( isset( $parsed_url['query'] ) ? "?$parsed_url[query]" : '' );
 		}
 
-		$preview = is_preview();
+		$is_content_page = is_preview() || is_singular();
 
 		$si_js_args = array(
 			'token' => get_option( 'siteimprove_token' ),
 			'txt'   => __( 'Siteimprove Recheck', 'siteimprove' ),
 			'url'   => $url,
 			'version' => $disabled_new_version,
-			'preview' => $preview,
+			'is_content_page' => $is_content_page,
 		);
 
 		wp_localize_script(

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -45,6 +45,12 @@
       this.method = "domain";
       this.common(url);
     },
+    clear: function (callback, token) {
+      this.callback = callback;
+      this.token = token;
+      this.method = "clear";
+      this.common();
+    },
     recheck: function (url, token) {
       this.url = url;
       this.token = token;
@@ -120,18 +126,18 @@
       
       // 0 = overlay-v1.js
       // 1 = overlay-latest.js
-      if(this.version == 1 && this.preview) {
+      if (this.version == 1 && this.preview) {
         _si.push(['registerPrepublishCallback', getDomCallback, this.token]);
       }
       _si.push([this.method, this.url, this.token]);
 
-      //Calling the "clear" method to avoid smallbox showing a "Page not found" message when inside wp-admin panel
+      // Calling the "clear" method to avoid smallbox showing a "Page not found" message when inside wp-admin panel
       // Do not do this for domain, so we can still see site-view of the plugin
-      if(this.method !== "domain") {
+      if (this.version == 0 && this.method !== "domain") {
         const pattern = /(?:\/wp-admin\/{1})[\D-\d]+.php/;
-        if (this.url.match(pattern)) {
+        if (this.url && this.url.match(pattern)) {
           setTimeout(() => {
-            _si.push(['clear']); 
+            _si.push(['clear', null, this.token]); 
           }, 500);
         }
       }
@@ -187,6 +193,8 @@
       // It will call domain only for v1
       if( "0" === siteimprove_domain.version ){
         siteimprove.domain(siteimprove_domain.url, siteimprove_domain.token);
+      } else {
+        siteimprove.clear(null, siteimprove_domain.token);
       }
     }
 

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -31,12 +31,12 @@
   };
 
   var siteimprove = {
-    input: function (url, token, version, preview) {
+    input: function (url, token, version, is_content_page) {
       this.url = url;
       this.token = token;
       this.method = "input";
       this.version = version;
-      this.preview = preview;
+      this.is_content_page = is_content_page;
       this.common(url);
     },
     domain: function (url, token) {
@@ -126,7 +126,7 @@
       
       // 0 = overlay-v1.js
       // 1 = overlay-latest.js
-      if (this.version == 1 && this.preview) {
+      if (this.version == 1 && this.is_content_page) {
         _si.push(['registerPrepublishCallback', getDomCallback, this.token]);
       }
       _si.push([this.method, this.url, this.token]);
@@ -185,7 +185,7 @@
 
     // If exist siteimprove_input, call input Siteimprove method.
     if (typeof siteimprove_input !== "undefined") {
-      siteimprove.input(siteimprove_input.url, siteimprove_input.token, siteimprove_input.version, siteimprove_input.preview);
+      siteimprove.input(siteimprove_input.url, siteimprove_input.token, siteimprove_input.version, siteimprove_input.is_content_page);
     }
 
     // If exist siteimprove_domain, call domain Siteimprove method.

--- a/siteimprove/readme.txt
+++ b/siteimprove/readme.txt
@@ -86,6 +86,10 @@ Please review whether you have JavaScript turned off in your browser. We use Jav
 
 == Changelog ==
 
+= 2.0.2 =
+* Added - Calling "clear" on non-content pages in WordPress
+* Added - Prepublish can now be started from a published page
+
 = 2.0.1 =
 * Bugfix - Fixed checkbox for "Use latest experience" was not properly checked on by default
 

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -9,7 +9,7 @@
  * Plugin Name:         Siteimprove Plugin
  * Plugin URI:          https://www.siteimprove.com/integrations/cms-plugin/wordpress/
  * Description:         Integration with Siteimprove.
- * Version:             2.0.1
+ * Version:             2.0.2
  * Author:              Siteimprove
  * Author URI:          http://www.siteimprove.com/
  * Requires at least:   4.7.2


### PR DESCRIPTION
DEMO: 
https://github.com/Siteimprove/CMS-plugin-Wordpress/assets/25395486/f68651c6-24ef-4b64-bd88-d539f847998b

* I added that we also add "Prepublish" button on published pages
* I added that we do "clear" on places that isn't content
* Did some cleanup in README files
