### PR TITLE
INS-2791: Empty wp-admin-bar to keep structure of highlights intact

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Every pull request will be checked against WPCS through GitHub Actions.
 
 ## Version History
 
+### 2.0.3
+* Bugfix - When doing prepublish, the si-preview empties the wp-admin-bar instead of removing it, which improves highlight selectors
+
 ### 2.0.2
 * Added - Calling "clear" on non-content pages in WordPress
 * Added - Prepublish can now be started from a published page

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -102,6 +102,10 @@ class Siteimprove_Admin {
 		wp_enqueue_script( 'siteimprove_admin_js', plugin_dir_url( __FILE__ ) . 'js/siteimprove-admin.js', array( 'jquery' ), $this->version, false );
 	}
 
+	public function siteimprove_preview() {
+		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove-remove-adminbar.js', array( 'jquery' ), $this->version, false );
+	}
+
 	/**
 	 * Initial actions.
 	 */
@@ -180,9 +184,10 @@ class Siteimprove_Admin {
 				$overlay_path = Siteimprove::JS_LIBRARY_URL . 'overlay-v1.js';
 			}
 		}
-
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove.js', array( 'jquery' ), $this->version, false );
-		wp_enqueue_script( 'siteimprove_overlay', $overlay_path, array(), $this->version, true );
+		if ( ! isset( $_GET['si_preview'] ) || '0' === $_GET['si_preview'] ) {
+			wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove.js', array( 'jquery' ), $this->version, false );
+			wp_enqueue_script( 'siteimprove_overlay', $overlay_path, array(), $this->version, true );
+		}
 		$public_url = get_option( 'siteimprove_public_url' );
 
 		if ( ! empty( $public_url ) ) {
@@ -190,14 +195,14 @@ class Siteimprove_Admin {
 			$url        = "$public_url$parsed_url[path]" . ( isset( $parsed_url['query'] ) ? "?$parsed_url[query]" : '' );
 		}
 
-		$preview = is_preview();
+		$is_content_page = is_preview() || is_singular();
 
 		$si_js_args = array(
 			'token' => get_option( 'siteimprove_token' ),
 			'txt'   => __( 'Siteimprove Recheck', 'siteimprove' ),
 			'url'   => $url,
 			'version' => $disabled_new_version,
-			'preview' => $preview,
+			'is_content_page' => $is_content_page,
 		);
 
 		wp_localize_script(

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -102,6 +102,10 @@ class Siteimprove_Admin {
 		wp_enqueue_script( 'siteimprove_admin_js', plugin_dir_url( __FILE__ ) . 'js/siteimprove-admin.js', array( 'jquery' ), $this->version, false );
 	}
 
+
+	/**
+	 * Siteimprove Preview - Enqueue this script to empty #wp-admin-bar
+	 */
 	public function siteimprove_preview() {
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove-remove-adminbar.js', array( 'jquery' ), $this->version, false );
 	}

--- a/siteimprove/admin/js/siteimprove-remove-adminbar.js
+++ b/siteimprove/admin/js/siteimprove-remove-adminbar.js
@@ -1,0 +1,8 @@
+window.onload = function() {
+    window.stop();
+    var adminBar = document.getElementById('wpadminbar');
+    if (adminBar) {
+        adminBar.innerHTML = '<div></div>';
+        adminBar.id = 'wpadminbar-disabled';
+    }
+};

--- a/siteimprove/admin/js/siteimprove-remove-adminbar.js
+++ b/siteimprove/admin/js/siteimprove-remove-adminbar.js
@@ -1,7 +1,7 @@
-window.onload = function() {
+window.addEventListener("load", function() {
     var adminBar = document.getElementById('wpadminbar');
     if (adminBar) {
         adminBar.innerHTML = '<div></div>';
         adminBar.id = 'wpadminbar-disabled';
     }
-};
+});

--- a/siteimprove/admin/js/siteimprove-remove-adminbar.js
+++ b/siteimprove/admin/js/siteimprove-remove-adminbar.js
@@ -1,5 +1,4 @@
 window.onload = function() {
-    window.stop();
     var adminBar = document.getElementById('wpadminbar');
     if (adminBar) {
         adminBar.innerHTML = '<div></div>';

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -31,12 +31,12 @@
   };
 
   var siteimprove = {
-    input: function (url, token, version, preview) {
+    input: function (url, token, version, is_content_page) {
       this.url = url;
       this.token = token;
       this.method = "input";
       this.version = version;
-      this.preview = preview;
+      this.is_content_page = is_content_page;
       this.common(url);
     },
     domain: function (url, token) {
@@ -44,6 +44,12 @@
       this.token = token;
       this.method = "domain";
       this.common(url);
+    },
+    clear: function (callback, token) {
+      this.callback = callback;
+      this.token = token;
+      this.method = "clear";
+      this.common();
     },
     recheck: function (url, token) {
       this.url = url;
@@ -120,7 +126,7 @@
       
       // 0 = overlay-v1.js
       // 1 = overlay-latest.js
-      if(this.version == 1 && this.preview) {
+      if (this.version == 1 && this.is_content_page) {
         _si.push(['registerPrepublishCallback', getDomCallback, this.token]);
       }
       _si.push([this.method, this.url, this.token]);
@@ -179,7 +185,7 @@
 
     // If exist siteimprove_input, call input Siteimprove method.
     if (typeof siteimprove_input !== "undefined") {
-      siteimprove.input(siteimprove_input.url, siteimprove_input.token, siteimprove_input.version, siteimprove_input.preview);
+      siteimprove.input(siteimprove_input.url, siteimprove_input.token, siteimprove_input.version, siteimprove_input.is_content_page);
     }
 
     // If exist siteimprove_domain, call domain Siteimprove method.

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -148,8 +148,7 @@ class Siteimprove {
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
 		if ( isset( $_GET['si_preview'] ) || '1' === $_GET['si_preview'] ) {
 			$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_preview' );
-		}
-		if ( ! isset( $_GET['si_preview'] ) || '0' === $_GET['si_preview'] ) {
+		} else {
 			$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
 			$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );
 			$this->loader->add_action( 'edit_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -145,10 +145,10 @@ class Siteimprove {
 		$this->loader->add_action( 'siteimprove_before_settings_form', $plugin_admin, 'siteimprove_before_settings_form' );
 
 		// Siteimprove Actions.
-		$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
 		if ( isset( $_GET['si_preview'] ) || '1' === $_GET['si_preview'] ) {
 			$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_preview' );
 		} else {
+			$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
 			$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
 			$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );
 			$this->loader->add_action( 'edit_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -149,13 +149,15 @@ class Siteimprove {
 		if ( isset( $_GET['si_preview'] ) || '1' === $_GET['si_preview'] ) {
 			$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_preview' );
 		}
-		$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
-		$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );
-		$this->loader->add_action( 'edit_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
-		$this->loader->add_action( 'create_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
-		$this->loader->add_action( 'transition_post_status', $plugin_admin, 'siteimprove_save_session_url_product', 10, 3 );
-		$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_wp_head' );
-		$this->loader->add_action( 'admin_bar_menu', $plugin_admin, 'add_prepublish_toolbar_item', 500, 1 );
+		if ( ! isset( $_GET['si_preview'] ) || '0' === $_GET['si_preview'] ) {
+			$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
+			$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );
+			$this->loader->add_action( 'edit_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
+			$this->loader->add_action( 'create_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
+			$this->loader->add_action( 'transition_post_status', $plugin_admin, 'siteimprove_save_session_url_product', 10, 3 );
+			$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_wp_head' );
+			$this->loader->add_action( 'admin_bar_menu', $plugin_admin, 'add_prepublish_toolbar_item', 500, 1 );
+		}
 	}
 
 	/**

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -145,16 +145,17 @@ class Siteimprove {
 		$this->loader->add_action( 'siteimprove_before_settings_form', $plugin_admin, 'siteimprove_before_settings_form' );
 
 		// Siteimprove Actions.
-		if ( ! isset( $_GET['si_preview'] ) || '0' === $_GET['si_preview'] ) {
-			$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
-			$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
-			$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );
-			$this->loader->add_action( 'edit_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
-			$this->loader->add_action( 'create_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
-			$this->loader->add_action( 'transition_post_status', $plugin_admin, 'siteimprove_save_session_url_product', 10, 3 );
-			$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_wp_head' );
-			$this->loader->add_action( 'admin_bar_menu', $plugin_admin, 'add_prepublish_toolbar_item', 500, 1 );
+		$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
+		if ( isset( $_GET['si_preview'] ) || '1' === $_GET['si_preview'] ) {
+			$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_preview' );
 		}
+		$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
+		$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );
+		$this->loader->add_action( 'edit_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
+		$this->loader->add_action( 'create_term', $plugin_admin, 'siteimprove_save_session_url_term', 10, 3 );
+		$this->loader->add_action( 'transition_post_status', $plugin_admin, 'siteimprove_save_session_url_product', 10, 3 );
+		$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_wp_head' );
+		$this->loader->add_action( 'admin_bar_menu', $plugin_admin, 'add_prepublish_toolbar_item', 500, 1 );
 	}
 
 	/**

--- a/siteimprove/readme.txt
+++ b/siteimprove/readme.txt
@@ -86,6 +86,9 @@ Please review whether you have JavaScript turned off in your browser. We use Jav
 
 == Changelog ==
 
+= 2.0.3 =
+* Bugfix - When doing prepublish, the si-preview empties the wp-admin-bar instead of removing it, which improves highlight selectors
+
 = 2.0.2 =
 * Added - Calling "clear" on non-content pages in WordPress
 * Added - Prepublish can now be started from a published page

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -25,16 +25,6 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 /**
- * Hide the WordPress admin bar when the `si_preview` parameter is present.
- */
-function si_preview() {
-	if ( isset( $_GET['si_preview'] ) && '1' === $_GET['si_preview'] ) {
-		add_filter( 'show_admin_bar', '__return_false' );
-	}
-}
-add_action( 'parse_query', 'si_preview' );
-
-/**
  * Include SiteimproveUtils class.
  */
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-siteimproveutils.php';

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -9,7 +9,7 @@
  * Plugin Name:         Siteimprove Plugin
  * Plugin URI:          https://www.siteimprove.com/integrations/cms-plugin/wordpress/
  * Description:         Integration with Siteimprove.
- * Version:             2.0.2
+ * Version:             2.0.3
  * Author:              Siteimprove
  * Author URI:          http://www.siteimprove.com/
  * Requires at least:   4.7.2


### PR DESCRIPTION
- I have changed si_preview to empty the contents of wp-admin-bar, and keep its place in the DOM intact. This is needed to keep the content in sync between preview and non-preview