### PR TITLE
INS-2804: WordPress: Use recheck callback and add it to Gutenberg editor too + Bugfix for undefined index

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Every pull request will be checked against WPCS through GitHub Actions.
 
 ## Version History
 
+### 2.0.4
+* Added - Siteimprove Recheck to Gutenberg Editor
+* Added - When recheck is complete, the button will be re-enabled
+* Bugfix - Fixed an issue with si_preview returning undefined index
+
 ### 2.0.3
 * Bugfix - When doing prepublish, the si-preview empties the wp-admin-bar instead of removing it, which improves highlight selectors
 

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -102,24 +102,21 @@ class Siteimprove_Admin {
 		wp_enqueue_script( 'siteimprove_admin_js', plugin_dir_url( __FILE__ ) . 'js/siteimprove-admin.js', array( 'jquery' ), $this->version, false );
 	}
 
-	
 	/**
 	 * Gutenberg script for adding buttons to its editor such as Recheck
 	 */
 	public function gutenberg_siteimprove_plugin() {
 		wp_enqueue_script(
 			'gutenberg-siteimprove-plugin',
-			plugin_dir_url(__FILE__) . 'js/siteimprove-gutenberg.js',
-			array('wp-plugins', 'wp-edit-post', 'wp-element', 'siteimprove'),
+			plugin_dir_url( __FILE__ ) . 'js/siteimprove-gutenberg.js',
+			array( 'wp-plugins', 'wp-edit-post', 'wp-element', 'siteimprove' ),
 			true
 		);
-		
 		$si_js_args = array(
-			'token' => get_option('siteimprove_token'),
-			'text' => __('Siteimprove Recheck', 'siteimprove'),
+			'token' => get_option( 'siteimprove_token' ),
+			'text' => __( 'Siteimprove Recheck', 'siteimprove' ),
 			'url' => get_permalink( $post_id )
 		);
-		
 		wp_localize_script('gutenberg-siteimprove-plugin', 'siteimprove_gutenberg_recheck', $si_js_args);		
 	}
 	

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -117,7 +117,11 @@ class Siteimprove_Admin {
 			'text' => __( 'Siteimprove Recheck', 'siteimprove' ),
 			'url' => get_permalink( $post_id ),
 		);
-		wp_localize_script( 'gutenberg-siteimprove-plugin', 'siteimprove_gutenberg_recheck', $si_js_args );		
+		wp_localize_script( 
+			'gutenberg-siteimprove-plugin', 
+			'siteimprove_gutenberg_recheck', 
+			$si_js_args 
+		);
 	}
 
 	/**

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -125,13 +125,6 @@ class Siteimprove_Admin {
 	}
 
 	/**
-	 * Siteimprove Preview - Enqueue this script to empty #wp-admin-bar
-	 */
-	public function siteimprove_preview() {
-		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove-remove-adminbar.js', array( 'jquery' ), $this->version, false );
-	}
-
-	/**
 	 * Initial actions.
 	 */
 	public function siteimprove_init() {

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -117,10 +117,10 @@ class Siteimprove_Admin {
 			'text' => __( 'Siteimprove Recheck', 'siteimprove' ),
 			'url' => get_permalink( $post_id ),
 		);
-		wp_localize_script( 
-			'gutenberg-siteimprove-plugin', 
-			'siteimprove_gutenberg_recheck', 
-			$si_js_args 
+		wp_localize_script(
+			'gutenberg-siteimprove-plugin',
+			'siteimprove_gutenberg_recheck',
+			$si_js_args
 		);
 	}
 

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -115,12 +115,10 @@ class Siteimprove_Admin {
 		$si_js_args = array(
 			'token' => get_option( 'siteimprove_token' ),
 			'text' => __( 'Siteimprove Recheck', 'siteimprove' ),
-			'url' => get_permalink( $post_id )
+			'url' => get_permalink( $post_id ),
 		);
-		wp_localize_script('gutenberg-siteimprove-plugin', 'siteimprove_gutenberg_recheck', $si_js_args);		
+		wp_localize_script( 'gutenberg-siteimprove-plugin', 'siteimprove_gutenberg_recheck', $si_js_args );		
 	}
-	
-
 
 	/**
 	 * Siteimprove Preview - Enqueue this script to empty #wp-admin-bar

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -102,6 +102,28 @@ class Siteimprove_Admin {
 		wp_enqueue_script( 'siteimprove_admin_js', plugin_dir_url( __FILE__ ) . 'js/siteimprove-admin.js', array( 'jquery' ), $this->version, false );
 	}
 
+	
+	/**
+	 * Gutenberg script for adding buttons to its editor such as Recheck
+	 */
+	public function gutenberg_siteimprove_plugin() {
+		wp_enqueue_script(
+			'gutenberg-siteimprove-plugin',
+			plugin_dir_url(__FILE__) . 'js/siteimprove-gutenberg.js',
+			array('wp-plugins', 'wp-edit-post', 'wp-element', 'siteimprove'),
+			true
+		);
+		
+		$si_js_args = array(
+			'token' => get_option('siteimprove_token'),
+			'text' => __('Siteimprove Recheck', 'siteimprove'),
+			'url' => get_permalink( $post_id )
+		);
+		
+		wp_localize_script('gutenberg-siteimprove-plugin', 'siteimprove_gutenberg_recheck', $si_js_args);		
+	}
+	
+
 
 	/**
 	 * Siteimprove Preview - Enqueue this script to empty #wp-admin-bar

--- a/siteimprove/admin/js/siteimprove-admin.js
+++ b/siteimprove/admin/js/siteimprove-admin.js
@@ -61,7 +61,6 @@
 							'action': 'siteimprove_prepublish_activation'
 						},
 						function (response) {
-							console.log( response.result );
 							if (response.result === true) {
 								$( '.siteimprove_prepublish_activation_messages' ).html( '<p>' + siteimprove_plugin_text.prepublish_activate_running + '</p>' );
 								siteimprove_check_if_activated();

--- a/siteimprove/admin/js/siteimprove-gutenberg.js
+++ b/siteimprove/admin/js/siteimprove-gutenberg.js
@@ -34,7 +34,7 @@ var RecheckButton = function () {
                     }
                 );
             } else {
-                console.error("Siteimprove has not been loaded");
+                console.error("Siteimprove Recheck: siteimprove.js has not been loaded");
             }
         } 
     }, siteimprove_gutenberg_recheck.text);

--- a/siteimprove/admin/js/siteimprove-gutenberg.js
+++ b/siteimprove/admin/js/siteimprove-gutenberg.js
@@ -25,7 +25,7 @@ var RecheckButton = function () {
         },
         onClick: function () {
             setClicked(true);
-            if (typeof window.siteimprove !== "undefined") {
+            if (typeof window.siteimprove.recheck !== "undefined") {
                 window.siteimprove.recheck(
                     siteimprove_gutenberg_recheck.url, 
                     siteimprove_gutenberg_recheck.token, 

--- a/siteimprove/admin/js/siteimprove-gutenberg.js
+++ b/siteimprove/admin/js/siteimprove-gutenberg.js
@@ -1,0 +1,49 @@
+var registerPlugin = wp.plugins.registerPlugin;
+var PluginDocumentSettingPanel = wp.editPost.PluginDocumentSettingPanel;
+var Button = wp.components.Button;
+var SVG = wp.components.SVG;
+var Path = wp.components.Path;
+
+var createElement = wp.element.createElement;
+var useState = wp.element.useState;
+
+var svgIcon = createElement(SVG, { xmlns:"http://www.w3.org/2000/svg", height:"24px", width:"24px", viewBox:"0 0 24 24", focusable:"false", 'aria-hidden':"true", fill:"currentColor" },
+    createElement(Path, { fill:"#141155", d:"M12.015625.113281C5.433594.113281.113281 5.433594.113281 12.015625c0 6.578125 5.320313 11.886719 11.902344 11.886719 6.578125 0 11.886719-5.324219 11.886719-11.886719 0-6.566406-5.324219-11.902344-11.886719-11.902344Zm0 0" }),
+    createElement(Path, { fill:"#fff", d:"m6.097656 14.796875 1.695313-1.003906c.367187.945312 1.074219 1.539062 2.328125 1.539062 1.257812 0 1.625-.507812 1.625-1.074219 0-.746093-.679688-1.042968-2.1875-1.480468-1.539063-.4375-3.050782-1.074219-3.050782-3.007813 0-1.933593 1.609376-2.992187 3.332032-2.992187s2.9375.847656 3.613281 2.257812l-1.664063.960938c-.367187-.777344-.917968-1.300782-1.949218-1.300782-.832032 0-1.328125.4375-1.328125 1.019532 0 .621094.382812.945312 1.921875 1.410156 1.609375.523438 3.316406 1.058594 3.316406 3.121094 0 1.890625-1.523438 3.046875-3.671875 3.046875-2.058594.015625-3.441406-.972657-3.980469-2.496094m8.667969-6.917969c0-.621094.507813-1.160156 1.144531-1.160156.636719 0 1.15625.539062 1.15625 1.160156 0 .621094-.507812 1.140625-1.15625 1.140625-.648437 0-1.144531-.519531-1.144531-1.140625m.214844 1.988282h1.863281v7.230468h-1.863281Zm0 0"})
+);
+
+var RecheckButton = function () {
+    var [isClicked, setClicked] = useState(false);
+
+    return createElement(Button, {
+        isPrimary: true,
+        disabled: isClicked,
+        style: {
+            width: '100%',
+            textAlign: 'center',
+            display: 'inline-block'
+        },
+        onClick: function () {
+            setClicked(true);
+            if (typeof window.siteimprove !== "undefined" && typeof window.siteimprove.recheck !== "undefined") {
+                window.siteimprove.recheck(siteimprove_gutenberg_recheck.url, siteimprove_gutenberg_recheck.token, function() { setClicked(false) });
+            } else {
+                console.error("Siteimprove has not been loaded");
+            }
+        } 
+    }, siteimprove_gutenberg_recheck.text);
+};
+
+registerPlugin('siteimprove-panel-settings', {
+    render: function () {
+        return createElement(
+            PluginDocumentSettingPanel,
+            {
+                name: 'siteimprove-panel',                
+                title: createElement('div', {style: { display: 'flex', alignItems: 'center', justifyContent: 'center' }}, svgIcon, createElement('span', {style: { marginLeft: '5px' }}, 'Siteimprove')),
+                className: 'siteimprove-panel',
+            },
+            createElement(RecheckButton)
+        );
+    },
+});

--- a/siteimprove/admin/js/siteimprove-gutenberg.js
+++ b/siteimprove/admin/js/siteimprove-gutenberg.js
@@ -25,8 +25,14 @@ var RecheckButton = function () {
         },
         onClick: function () {
             setClicked(true);
-            if (typeof window.siteimprove !== "undefined" && typeof window.siteimprove.recheck !== "undefined") {
-                window.siteimprove.recheck(siteimprove_gutenberg_recheck.url, siteimprove_gutenberg_recheck.token, function() { setClicked(false) });
+            if (typeof window.siteimprove !== "undefined") {
+                window.siteimprove.recheck(
+                    siteimprove_gutenberg_recheck.url, 
+                    siteimprove_gutenberg_recheck.token, 
+                    function() { 
+                        setClicked(false) 
+                    }
+                );
             } else {
                 console.error("Siteimprove has not been loaded");
             }

--- a/siteimprove/admin/js/siteimprove-remove-adminbar.js
+++ b/siteimprove/admin/js/siteimprove-remove-adminbar.js
@@ -1,7 +1,0 @@
-window.addEventListener("load", function() {
-    var adminBar = document.getElementById('wpadminbar');
-    if (adminBar) {
-        adminBar.innerHTML = '<div></div>';
-        adminBar.id = 'wpadminbar-disabled';
-    }
-});

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -17,6 +17,7 @@
       iframe.addEventListener(
         "load",
         () => {
+          // In order to preserve the DOM node hierarchy for highlights, we have chosen to empty the #wp-admin-bar from the new DOM instead of outright removing it.
           var adminBar = iframe.contentWindow.document.getElementById('wpadminbar');
           if (adminBar) {
             adminBar.innerHTML = '<div></div>';

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -6,20 +6,25 @@
   "use strict";
 
   const getDom = async function (url) {
-    const newDiv = document.createElement("div");
-    newDiv.setAttribute("id","div_iframe"); 
-    document.body.appendChild(newDiv);
+    const iframeContainer = document.createElement("div");
+    iframeContainer.setAttribute("id", "div_iframe");
+    document.body.appendChild(iframeContainer);
     //Opens an alternative version of this page without wp injected content such as the wp-admin bar and smallbox plugin itself as this is for the DOM we send to Siteimprove
-    newDiv.innerHTML = "<iframe id='domIframe' src="+ url.concat("&si_preview=1") +" style='height:100vh; width:100%'></iframe>";
-
+    const separator = url.includes("?") ? "&" : "?";
+    iframeContainer.innerHTML = `<iframe id='domIframe' src=${url}${separator}si_preview=1 style='height:100vh; width:100%'></iframe>`;
+    const iframe = document.getElementById("domIframe");
     const promise = new Promise(function (resolve, reject) {
-      const iframe = document.getElementById("domIframe");
       iframe.addEventListener(
         "load",
         () => {
-            const newDocument = iframe.contentWindow.document.cloneNode(true);
-            document.body.removeChild(newDiv);
-            resolve(newDocument);
+          var adminBar = iframe.contentWindow.document.getElementById('wpadminbar');
+          if (adminBar) {
+            adminBar.innerHTML = '<div></div>';
+            adminBar.id = 'wpadminbar-disabled';
+          }
+          const cleanDom = iframe.contentWindow.document.cloneNode(true);
+          document.body.removeChild(iframeContainer);
+          resolve(cleanDom);
         },
         { once: true }
       );
@@ -28,7 +33,7 @@
     const documentReturned = await promise;
     $(".si-overlay").remove();
     return documentReturned;
-  };
+  };  
 
   window.siteimprove = {
     input: function (url, token, version, is_content_page) {

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -196,7 +196,7 @@
 
     // If exist siteimprove_recheck, call recheck Siteimprove method.
     if (typeof siteimprove_recheck !== "undefined") {
-      siteimprove.recheck(siteimprove_recheck.url, siteimprove_recheck.token, siteimprove_recheck.callback);
+      siteimprove.recheck(siteimprove_recheck.url, siteimprove_recheck.token);
     }
 
     // If exist siteimprove_input, call input Siteimprove method.

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -30,7 +30,7 @@
     return documentReturned;
   };
 
-  var siteimprove = {
+  window.siteimprove = {
     input: function (url, token, version, is_content_page) {
       this.url = url;
       this.token = token;
@@ -51,7 +51,8 @@
       this.method = "clear";
       this.common();
     },
-    recheck: function (url, token) {
+    recheck: function (url, token, callback) {
+      this.callback = callback;
       this.url = url;
       this.token = token;
       this.method = "recheck";
@@ -80,6 +81,16 @@
           this.url,
           this.token,
           this.callback,
+        ]);
+        return;
+      } 
+
+      if (this.method == "recheck") {
+        _si.push([
+          this.method,
+          this.url,
+          this.token,
+          this.callback
         ]);
         return;
       }
@@ -129,6 +140,8 @@
       if (this.version == 1 && this.is_content_page) {
         _si.push(['registerPrepublishCallback', getDomCallback, this.token]);
       }
+
+
       _si.push([this.method, this.url, this.token]);
 
       // Calling the "clear" method to avoid smallbox showing a "Page not found" message when inside wp-admin panel
@@ -164,11 +177,14 @@
         }
 
         $(".recheck-button").click(function () {
+          $(this).attr("disabled", true);
           siteimprove.recheck(
             siteimprove_recheck_button.url,
-            siteimprove_recheck_button.token
+            siteimprove_recheck_button.token,
+            function () {
+              $(".recheck-button").attr("disabled", false);
+            }
           );
-          $(this).attr("disabled", true);
           return false;
         });
       },
@@ -180,7 +196,7 @@
 
     // If exist siteimprove_recheck, call recheck Siteimprove method.
     if (typeof siteimprove_recheck !== "undefined") {
-      siteimprove.recheck(siteimprove_recheck.url, siteimprove_recheck.token);
+      siteimprove.recheck(siteimprove_recheck.url, siteimprove_recheck.token, siteimprove_recheck.callback);
     }
 
     // If exist siteimprove_input, call input Siteimprove method.

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -9,7 +9,6 @@
     const iframeContainer = document.createElement("div");
     iframeContainer.setAttribute("id", "div_iframe");
     document.body.appendChild(iframeContainer);
-    //Opens an alternative version of this page without wp injected content such as the wp-admin bar and smallbox plugin itself as this is for the DOM we send to Siteimprove
     const separator = url.includes("?") ? "&" : "?";
     iframeContainer.innerHTML = `<iframe id='domIframe' src=${url}${separator}si_preview=1 style='height:100vh; width:100%'></iframe>`;
     const iframe = document.getElementById("domIframe");

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -146,9 +146,7 @@ class Siteimprove {
 		$this->loader->add_action( 'siteimprove_before_settings_form', $plugin_admin, 'siteimprove_before_settings_form' );
 
 		// Siteimprove Actions.
-		if ( isset( $_GET['si_preview'] ) && '1' === $_GET['si_preview'] ) {
-			$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_preview' );
-		} else {
+		if ( ! isset( $_GET['si_preview'] ) || '0' === $_GET['si_preview'] ) {
 			$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );
 			$this->loader->add_action( 'publish_page', $plugin_admin, 'siteimprove_save_session_url_post' );
 			$this->loader->add_action( 'publish_post', $plugin_admin, 'siteimprove_save_session_url_post' );

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -135,6 +135,7 @@ class Siteimprove {
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_admin, 'enqueue_preview_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
+		$this->loader->add_action( 'enqueue_block_editor_assets', $plugin_admin, 'gutenberg_siteimprove_plugin' );
 
 		// Settings form.
 		$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_settings' );
@@ -145,7 +146,7 @@ class Siteimprove {
 		$this->loader->add_action( 'siteimprove_before_settings_form', $plugin_admin, 'siteimprove_before_settings_form' );
 
 		// Siteimprove Actions.
-		if ( isset( $_GET['si_preview'] ) || '1' === $_GET['si_preview'] ) {
+		if ( isset( $_GET['si_preview'] ) && '1' === $_GET['si_preview'] ) {
 			$this->loader->add_action( 'wp_head', $plugin_admin, 'siteimprove_preview' );
 		} else {
 			$this->loader->add_action( 'admin_init', $plugin_admin, 'siteimprove_init' );

--- a/siteimprove/readme.txt
+++ b/siteimprove/readme.txt
@@ -87,7 +87,7 @@ Please review whether you have JavaScript turned off in your browser. We use Jav
 == Changelog ==
 = 2.0.4 =
 * Added - Siteimprove Recheck to Gutenberg Editor
-* Added - When recheck is complete, the button will be re-enabled.
+* Added - When recheck is complete, the button will be re-enabled
 * Bugfix - Fixed an issue with si_preview returning undefined index
 
 = 2.0.3 =

--- a/siteimprove/readme.txt
+++ b/siteimprove/readme.txt
@@ -85,6 +85,10 @@ Please review whether you have JavaScript turned off in your browser. We use Jav
 
 
 == Changelog ==
+= 2.0.4 =
+* Added - Siteimprove Recheck to Gutenberg Editor
+* Added - When recheck is complete, the button will be re-enabled.
+* Bugfix - Fixed an issue with si_preview returning undefined index
 
 = 2.0.3 =
 * Bugfix - When doing prepublish, the si-preview empties the wp-admin-bar instead of removing it, which improves highlight selectors

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -9,7 +9,7 @@
  * Plugin Name:         Siteimprove Plugin
  * Plugin URI:          https://www.siteimprove.com/integrations/cms-plugin/wordpress/
  * Description:         Integration with Siteimprove.
- * Version:             2.0.3
+ * Version:             2.0.4
  * Author:              Siteimprove
  * Author URI:          http://www.siteimprove.com/
  * Requires at least:   4.7.2


### PR DESCRIPTION
= 2.0.4 =
* Added - Siteimprove Recheck to Gutenberg Editor
* Added - When recheck is complete, the button will be re-enabled
* Bugfix - Fixed an issue with si_preview returning undefined index

Changed how removing the wp-admin-bar works.

Gutenberg: 
![image](https://github.com/Siteimprove/CMS-plugin-Wordpress/assets/25395486/4c3360a6-2b81-4f61-b531-b220ac609739)

Classic Editor:
![image](https://github.com/Siteimprove/CMS-plugin-Wordpress/assets/25395486/1b7a44b5-5991-422c-bda0-2e1e9b58cdfa)
