### PR TITLE
INS-2935: Implement nonce checking for Request Token action

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ The code on this repository has to match the WordPress Coding Standards in order
 Every pull request will be checked against WPCS through GitHub Actions.
 
 ## Version History
+### 2.0.7
+* Bugfix - Fixed a security issue with implementing nonce checking on request token
+
 ### 2.0.6
 * Bugfix - Fixed an issue when some users tried saving their API credentials
 

--- a/siteimprove/admin/js/siteimprove-admin.js
+++ b/siteimprove/admin/js/siteimprove-admin.js
@@ -37,7 +37,8 @@
 					$.post(
 						ajaxurl,
 						{
-							'action': 'siteimprove_request_token'
+							'action': 'siteimprove_request_token',
+							'_wpnonce': $( '#_wpnonce' ).val(),
 						},
 						function (response) {
 							var el = $( '#siteimprove_token_request' );

--- a/siteimprove/admin/partials/class-siteimprove-admin-settings.php
+++ b/siteimprove/admin/partials/class-siteimprove-admin-settings.php
@@ -714,7 +714,15 @@ class Siteimprove_Admin_Settings {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-		echo esc_html( SiteimproveUtils::request_token() );
+	
+		// Check if the nonce is set and is valid.
+		if ( isset( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'siteimprove-options' ) ) {
+			// The nonce is valid, output the token.
+			echo esc_html( SiteimproveUtils::request_token() );
+		} else {
+			wp_die();
+		}
+	
 		wp_die();
 	}
 }

--- a/siteimprove/readme.txt
+++ b/siteimprove/readme.txt
@@ -2,7 +2,7 @@
 Contributors: siteimprove
 Tags: accessibility, analytics, insights, readability, spelling, seo
 Requires at least: 4.7.2
-Tested up to: 6.2.2
+Tested up to: 6.4.3
 Stable tag: trunk
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -85,6 +85,9 @@ Please review whether you have JavaScript turned off in your browser. We use Jav
 
 
 == Changelog ==
+= 2.0.7 =
+* Bugfix - Fixed a security issue with implementing nonce checking on request token
+
 = 2.0.6 =
 * Bugfix - Fixed an issue when some users tried saving their API credentials
 

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -9,7 +9,7 @@
  * Plugin Name:         Siteimprove Plugin
  * Plugin URI:          https://www.siteimprove.com/integrations/cms-plugin/wordpress/
  * Description:         Integration with Siteimprove.
- * Version:             2.0.6
+ * Version:             2.0.7
  * Author:              Siteimprove
  * Author URI:          http://www.siteimprove.com/
  * Requires at least:   4.7.2


### PR DESCRIPTION
#  Task
We did not have nonce checking on our request action which led to a third-party creating a report on WordPress Marketplace expressing concern for security with CSRF attacks

# Solution
I am now implementing sending our `_wpnonce` as part of the action and validating that nonce hasn't been tampered with.