### PR TITLE
INS-2938: Fix README and change name of plugin

### DIFF
--- a/siteimprove/readme.txt
+++ b/siteimprove/readme.txt
@@ -1,13 +1,13 @@
 === Siteimprove ===
 Contributors: siteimprove
-Tags: accessibility, analytics, insights, readability, spelling, seo
+Tags: accessibility, analytics, insights, spelling, seo
 Requires at least: 4.7.2
 Tested up to: 6.4.3
-Stable tag: trunk
+Stable tag: 2.0.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Turn your most complex website challenges into manageable tasks—all from a single platform. Siteimprove is a comprehensive solution for every element of your marketing strategy—complete with three solution packages: Inclusivity, Content Experience, Marketing Performance.
+Turn your most complex website challenges into manageable tasks—all from a single platform
 
 == Description ==
 
@@ -86,6 +86,7 @@ Please review whether you have JavaScript turned off in your browser. We use Jav
 
 == Changelog ==
 = 2.0.7 =
+* Change - Changed name of the plugin from "Siteimprove Plugin" to "Siteimprove"
 * Bugfix - Fixed a security issue with implementing nonce checking on request token
 
 = 2.0.6 =

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Plugin Name:         Siteimprove Plugin
+ * Plugin Name:         Siteimprove
  * Plugin URI:          https://www.siteimprove.com/integrations/cms-plugin/wordpress/
  * Description:         Integration with Siteimprove.
  * Version:             2.0.7


### PR DESCRIPTION
# Fixes following issues
- The plugin name includes a restricted term. Your chosen plugin name - 'Siteimprove Plugin' - contains the restricted term 'plugin' which cannot be used at all in your plugin name
- The 'Short Description' section is too long and was truncated. A maximum of 150 characters is supported.
- One or more tags were ignored. Please limit your plugin to 5 tags.
- The Stable Tag in your readme file does not match the version in your main plugin file.
- It's recommended not to use 'Stable Tag: trunk'.