### PR TITLE
INS-2723: Disabled the prepublish if missing API credentials

### DIFF
--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -16,7 +16,7 @@ jobs:
             excludes: '' # Paths to excludes, space separated
             standard: 'WordPress' # Standard to use. Accepts WordPress|WordPress-Core|WordPress-Docs|WordPress-Extra|WordPress-VIP-Go|WordPressVIPMinimum.
             standard_repo: '' # Public (git) repository URL of the coding standard
-            repo_branch: 'master' # Branch of Standard repository
+            repo_branch: 'main' # Branch of Standard repository
             phpcs_bin_path: 'phpcs' # Custom PHPCS bin path
             use_local_config: 'true' # Use local config if available
             extra_args: '' # Extra arguments passing to the command

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -211,13 +211,13 @@ class Siteimprove_Admin {
 			wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove.js', array( 'jquery' ), $this->version, false );
 
 			/*
-								Pass any server-side vars down to JS.  These will be exposed as
-								php_vars.variablename for example
-						*/
+									 Pass any server-side vars down to JS.  These will be exposed as
+									 php_vars.variablename for example
+							 */
 			$jsarray = array(
 				'prepublish_allowed' => intval( get_option( 'siteimprove_prepublish_allowed', 0 ) ),
 				'prepublish_enabled' => intval( get_option( 'siteimprove_prepublish_enabled', 0 ) ),
-				'has_api_key' => intval( strlen( get_option( 'siteimprove_api_key', 0 ) ) > 0 )
+				'has_api_key' => intval( strlen( get_option( 'siteimprove_api_key', 0 ) ) > 0 ),
 			);
 			wp_localize_script( $this->plugin_name, 'php_vars', $jsarray );
 			wp_enqueue_script( 'siteimprove_overlay', $overlay_path, array(), $this->version, true );

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -216,6 +216,8 @@ class Siteimprove_Admin {
 					php_vars.variablename for example
 			*/
 			$jsarray = array(
+				'prepublish_allowed'        => intval( get_option( 'siteimprove_prepublish_allowed', 0 ) ),
+				'prepublish_enabled'        => intval( get_option( 'siteimprove_prepublish_enabled', 0 ) ),
 				'has_api_key'               => intval( strlen(get_option('siteimprove_api_key', 0)) > 0 )
 			);
 			wp_localize_script( $this->plugin_name, 'php_vars', $jsarray ); 

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -49,7 +49,7 @@ class Siteimprove_Admin {
 	public function __construct( $plugin_name, $version ) {
 
 		$this->plugin_name = $plugin_name;
-		$this->version     = $version;
+		$this->version = $version;
 
 		$this->load_dependencies();
 
@@ -135,10 +135,10 @@ class Siteimprove_Admin {
 
 		if ( ! wp_doing_ajax() && ! empty( $urls ) ) {
 			if ( is_array( $urls ) && count( $urls ) > 1 ) {
-				$url    = esc_url( home_url() );
+				$url = esc_url( home_url() );
 				$method = 'siteimprove_recrawl';
 			} else {
-				$url    = array_pop( $urls );
+				$url = array_pop( $urls );
 				$method = 'siteimprove_recheck';
 			}
 			delete_transient( 'siteimprove_url_' . get_current_user_id() );
@@ -147,7 +147,7 @@ class Siteimprove_Admin {
 
 		switch ( $pagenow ) {
 			case 'post.php':
-				$post_id   = wp_verify_nonce( $this->settings->request_siteimprove_nonce(), 'siteimprove_nonce' ) && ! empty( $_GET['post'] ) ? (int) $_GET['post'] : 0;
+				$post_id = wp_verify_nonce( $this->settings->request_siteimprove_nonce(), 'siteimprove_nonce' ) && ! empty( $_GET['post'] ) ? (int) $_GET['post'] : 0;
 				$permalink = get_permalink( $post_id );
 
 				if ( $permalink ) {
@@ -161,7 +161,7 @@ class Siteimprove_Admin {
 
 			case 'term.php':
 			case 'edit-tags.php':
-				$tag_id   = wp_verify_nonce( $this->settings->request_siteimprove_nonce(), 'siteimprove_nonce' ) && ! empty( $_GET['tag_ID'] ) ? (int) $_GET['tag_ID'] : 0;
+				$tag_id = wp_verify_nonce( $this->settings->request_siteimprove_nonce(), 'siteimprove_nonce' ) && ! empty( $_GET['tag_ID'] ) ? (int) $_GET['tag_ID'] : 0;
 				$taxonomy = wp_verify_nonce( $this->settings->request_siteimprove_nonce(), 'siteimprove_nonce' ) && ! empty( $_GET['taxonomy'] ) ? sanitize_key( $_GET['taxonomy'] ) : '';
 
 				if ( 'term.php' === $pagenow || ( 'edit-tags.php' === $pagenow && wp_verify_nonce( $this->settings->request_siteimprove_nonce(), 'siteimprove_nonce' ) && ! empty( $_GET['action'] ) && 'edit' === $_GET['action'] ) ) {
@@ -171,7 +171,7 @@ class Siteimprove_Admin {
 				break;
 
 			default:
-				$host    = isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+				$host = isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
 				$request = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 				$this->siteimprove_add_js( $host . $request, 'siteimprove_domain' );
 		}
@@ -207,35 +207,34 @@ class Siteimprove_Admin {
 
 		if ( isset( $_GET['si_preview_nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['si_preview_nonce'] ) ), 'siteimprove_nonce' ) ) {
 			return;
-		}
-		else {	
+		} else {
 			wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove.js', array( 'jquery' ), $this->version, false );
 
 			/*
-					Pass any server-side vars down to JS.  These will be exposed as
-					php_vars.variablename for example
-			*/
+								Pass any server-side vars down to JS.  These will be exposed as
+								php_vars.variablename for example
+						*/
 			$jsarray = array(
-				'prepublish_allowed'        => intval( get_option( 'siteimprove_prepublish_allowed', 0 ) ),
-				'prepublish_enabled'        => intval( get_option( 'siteimprove_prepublish_enabled', 0 ) ),
-				'has_api_key'               => intval( strlen(get_option('siteimprove_api_key', 0)) > 0 )
+				'prepublish_allowed' => intval( get_option( 'siteimprove_prepublish_allowed', 0 ) ),
+				'prepublish_enabled' => intval( get_option( 'siteimprove_prepublish_enabled', 0 ) ),
+				'has_api_key' => intval( strlen( get_option( 'siteimprove_api_key', 0 ) ) > 0 )
 			);
-			wp_localize_script( $this->plugin_name, 'php_vars', $jsarray ); 
+			wp_localize_script( $this->plugin_name, 'php_vars', $jsarray );
 			wp_enqueue_script( 'siteimprove_overlay', $overlay_path, array(), $this->version, true );
 		}
 		$public_url = get_option( 'siteimprove_public_url' );
 
 		if ( ! empty( $public_url ) ) {
 			$parsed_url = wp_parse_url( $url );
-			$url        = "$public_url$parsed_url[path]" . ( isset( $parsed_url['query'] ) ? "?$parsed_url[query]" : '' );
+			$url = "$public_url$parsed_url[path]" . ( isset( $parsed_url['query'] ) ? "?$parsed_url[query]" : '' );
 		}
 
 		$is_content_page = is_preview() || is_singular();
 
 		$si_js_args = array(
 			'token' => get_option( 'siteimprove_token' ),
-			'txt'   => __( 'Siteimprove Recheck', 'siteimprove' ),
-			'url'   => $url,
+			'txt' => __( 'Siteimprove Recheck', 'siteimprove' ),
+			'url' => $url,
 			'version' => $disabled_new_version,
 			'is_content_page' => $is_content_page,
 			'nonce' => $nonce,
@@ -252,9 +251,9 @@ class Siteimprove_Admin {
 			$this->plugin_name,
 			'siteimprove_plugin_text',
 			array(
-				'loading'                     => __( 'Loading... Please wait.', 'siteimprove' ),
+				'loading' => __( 'Loading... Please wait.', 'siteimprove' ),
 				'prepublish_activate_running' => __( 'We are now activating prepublish for your website... Please keep the current page open while the process is running.', 'siteimprove' ),
-				'prepublish_feature_ready'    => __( 'Prepublish feature is already enabled for the current website. To use it please go to the preview of any page/post or content that you want to check and click the button <strong>Siteimprove Prepublish Check</strong> located on the top bar of the admin panel.', 'siteimprove' ),
+				'prepublish_feature_ready' => __( 'Prepublish feature is already enabled for the current website. To use it please go to the preview of any page/post or content that you want to check and click the button <strong>Siteimprove Prepublish Check</strong> located on the top bar of the admin panel.', 'siteimprove' ),
 				'prepublish_activation_error' => __( 'Error activating prepublish. Please contact support team.', 'siteimprove' ),
 			)
 		);
@@ -308,7 +307,7 @@ class Siteimprove_Admin {
 	 */
 	public function siteimprove_save_session_url_post( $post_ID ) {
 		if ( ! wp_is_post_revision( $post_ID ) && ! wp_is_post_autosave( $post_ID ) ) {
-			$urls   = get_transient( 'siteimprove_url_' . get_current_user_id() );
+			$urls = get_transient( 'siteimprove_url_' . get_current_user_id() );
 			$urls[] = get_permalink( $post_ID );
 			set_transient( 'siteimprove_url_' . get_current_user_id(), $urls, 900 );
 		}
@@ -323,7 +322,7 @@ class Siteimprove_Admin {
 	 * @return void
 	 */
 	public function siteimprove_save_session_url_term( $term_id, $tt_id, $taxonomy ) {
-		$urls   = get_transient( 'siteimprove_url_' . get_current_user_id() );
+		$urls = get_transient( 'siteimprove_url_' . get_current_user_id() );
 		$urls[] = get_term_link( (int) $term_id, $taxonomy );
 		set_transient( 'siteimprove_url_' . get_current_user_id(), $urls, 900 );
 	}
@@ -346,7 +345,7 @@ class Siteimprove_Admin {
 				true
 			)
 		) {
-			$urls   = get_transient( 'siteimprove_url_' . get_current_user_id() );
+			$urls = get_transient( 'siteimprove_url_' . get_current_user_id() );
 			$urls[] = get_permalink( $post->ID );
 			set_transient( 'siteimprove_url_' . get_current_user_id(), $urls, 900 );
 		}
@@ -357,7 +356,7 @@ class Siteimprove_Admin {
 	 */
 	public function siteimprove_wp_head() {
 
-		$user          = wp_get_current_user();
+		$user = wp_get_current_user();
 		$allowed_roles = array(
 			'shop_manager',
 			'contributor',
@@ -378,7 +377,7 @@ class Siteimprove_Admin {
 					break;
 
 				default:
-					$host    = isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
+					$host = isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : '';
 					$request = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 					$this->siteimprove_add_js( $host . $request, 'siteimprove_domain' );
 			}
@@ -438,8 +437,8 @@ class Siteimprove_Admin {
 		$prepublish_enabled = intval( get_option( 'siteimprove_prepublish_enabled', 0 ) );
 		$has_api_key = intval( strlen( get_option( 'siteimprove_api_key', 0 ) ) > 0 );
 		if ( ( is_preview() || is_singular() ) && 1 === $prepublish_allowed && 1 === $prepublish_enabled && 1 === $has_api_key ) {
-			$prepublish_button = 
-			'<svg version="1.1" xmlns="http://www.w3.org/2000/svg" height="28px" width="28px" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="28px" height="28px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
+			$prepublish_button =
+				'<svg version="1.1" xmlns="http://www.w3.org/2000/svg" height="28px" width="28px" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="28px" height="28px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
 				<circle fill="#0D4CD3" cx="150" cy="150" r="150"/>
 				<g>
 					<path fill="#FFFFFF" d="M167.9,135.3l-14.3-4.2c-6.5-2-11.6-3.8-15.4-5.4c-3.8-1.6-6.5-3.4-8.1-5.2c-1.6-1.8-2.4-4.1-2.4-6.9   c0-3.4,1.1-6.3,3.2-8.7c2.1-2.5,5.1-4.4,9-5.7c3.8-1.3,8.3-2,13.5-2c5.2,0,10.4,0.7,15.6,2c5.2,1.3,9.9,3.2,14.3,5.5   c4.4,2.3,8,5.1,11,8.2l19-28.1c-6.5-6.3-15.1-11.2-25.7-14.8c-10.7-3.6-22.2-5.5-34.6-5.5c-9,0-17.3,1.3-24.9,3.8   c-7.6,2.5-14.2,6.1-19.9,10.7c-5.6,4.6-10,10-13.1,16.2c-3.1,6.2-4.7,13-4.7,20.3c0,11.4,3.7,21.2,11.1,29.3   c7.4,8.1,19.6,14.5,36.5,19.2l14.1,4c9.9,2.7,16.7,5.4,20.3,8.3c3.6,2.9,5.5,6.4,5.5,10.7c0,5.2-2.5,9.1-7.6,11.8   c-5,2.7-11.6,4-19.6,4c-5.7,0-11.6-0.7-17.6-2.2c-6.1-1.4-11.7-3.5-17.1-6.2c-5.3-2.7-9.7-5.8-13.1-9.5l-18.3,29.1   c8.1,7,18.1,12.3,29.8,15.9c11.7,3.7,23.8,5.5,36.2,5.5c13.4,0,24.9-2.2,34.6-6.7s17.2-10.6,22.6-18.6c5.3-7.9,8-17.1,8-27.5   c0-11.9-3.8-21.5-11.3-29C196.8,146.4,184.7,140.2,167.9,135.3z"/>
@@ -447,11 +446,11 @@ class Siteimprove_Admin {
 			</svg>';
 			$admin_bar->add_menu(
 				array(
-					'id'    => 'siteimprove-trigger-contentcheck',
+					'id' => 'siteimprove-trigger-contentcheck',
 					'title' => $prepublish_button . __( 'Prepublish', 'siteimprove' ),
 					'group' => null,
-					'href'  => '#',
-					'meta'  => array(
+					'href' => '#',
+					'meta' => array(
 						'title' => __( 'Siteimprove Prepublish', 'siteimprove' ),
 						'class' => 'siteimprove-trigger-contentcheck',
 					),

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -210,6 +210,15 @@ class Siteimprove_Admin {
 		}
 		else {	
 			wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/siteimprove.js', array( 'jquery' ), $this->version, false );
+
+			/*
+					Pass any server-side vars down to JS.  These will be exposed as
+					php_vars.variablename for example
+			*/
+			$jsarray = array(
+				'has_api_key'               => intval( strlen(get_option('siteimprove_api_key', 0)) > 0 )
+			);
+			wp_localize_script( $this->plugin_name, 'php_vars', $jsarray ); 
 			wp_enqueue_script( 'siteimprove_overlay', $overlay_path, array(), $this->version, true );
 		}
 		$public_url = get_option( 'siteimprove_public_url' );
@@ -425,8 +434,8 @@ class Siteimprove_Admin {
 		global $pagenow;
 		$prepublish_allowed = intval( get_option( 'siteimprove_prepublish_allowed', 0 ) );
 		$prepublish_enabled = intval( get_option( 'siteimprove_prepublish_enabled', 0 ) );
-
-		if ( ( is_preview() || is_singular() ) && 1 === $prepublish_allowed && 1 === $prepublish_enabled ) {
+		$has_api_key = intval( strlen( get_option( 'siteimprove_api_key', 0 ) ) > 0 );
+		if ( ( is_preview() || is_singular() ) && 1 === $prepublish_allowed && 1 === $prepublish_enabled && 1 === $has_api_key ) {
 			$prepublish_button = 
 			'<svg version="1.1" xmlns="http://www.w3.org/2000/svg" height="28px" width="28px" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="28px" height="28px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
 				<circle fill="#0D4CD3" cx="150" cy="150" r="150"/>

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -170,10 +170,15 @@
       // 0 = overlay-v1.js
       // 1 = overlay-latest.js
       if (this.version == 1 && this.is_content_page) {
-        var cb = Boolean(+php_vars.has_api_key) ? getDomCallback : null
+        var { has_api_key, prepublish_allowed, prepublish_enabled } = php_vars;
+        var cb =
+          Boolean(+has_api_key) &&
+          Boolean(+prepublish_allowed) &&
+          Boolean(+prepublish_enabled)
+            ? getDomCallback
+            : null
         _si.push(['registerPrepublishCallback', cb, this.token]);
       }
-
 
       _si.push([this.method, this.url, this.token]);
 

--- a/siteimprove/admin/js/siteimprove.js
+++ b/siteimprove/admin/js/siteimprove.js
@@ -170,7 +170,8 @@
       // 0 = overlay-v1.js
       // 1 = overlay-latest.js
       if (this.version == 1 && this.is_content_page) {
-        _si.push(['registerPrepublishCallback', getDomCallback, this.token]);
+        var cb = Boolean(+php_vars.has_api_key) ? getDomCallback : null
+        _si.push(['registerPrepublishCallback', cb, this.token]);
       }
 
 

--- a/siteimprove/admin/partials/class-siteimprove-admin-settings.php
+++ b/siteimprove/admin/partials/class-siteimprove-admin-settings.php
@@ -178,87 +178,87 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_settings_section_title( $args ) {
 		if ( 'siteimprove_prepublish' === $args['id'] ) {
 			$siteimprove_api_key = get_option( 'siteimprove_api_key', '' );
-			$prepublish_allowed  = intval( get_option( 'siteimprove_prepublish_allowed', 0 ) );
-			$prepublish_enabled  = intval( get_option( 'siteimprove_prepublish_enabled', 0 ) );
+			$prepublish_allowed = intval( get_option( 'siteimprove_prepublish_allowed', 0 ) );
+			$prepublish_enabled = intval( get_option( 'siteimprove_prepublish_enabled', 0 ) );
 			if ( ! empty( $siteimprove_api_key ) ) {
 				if ( 1 === $prepublish_allowed ) {
 					?>
-					<p>You can use Prepublish on your account.</p>
-					<?php
-					if ( 0 === $prepublish_enabled ) :
-						?>
-							<p class="siteimprove_prepublish_activation_messages">
-						<?php
-						echo wp_kses(
-							__( 'To enable prepublish for this website click <a href="#" id="siteimprove_enable_prepublish" class="button button-primary">here</a>', 'siteimprove' ),
-							array(
-								'a' => array(
-									'href'  => array(),
-									'id'    => array(),
-									'class' => array(),
-								),
-							)
-						);
-						?>
-							</p>
-							<?php
-						else :
-							?>
-						<p>
-							<?php
-							echo wp_kses(
-								__( 'Prepublish feature is already enabled for the current website. To use it please go to the preview of any page/post or content that you want to check and click the button <strong>Siteimprove Prepublish Check</strong> located on the top bar of the admin panel', 'siteimprove' ),
-								array(
-									'strong' => array(),
-								)
-							);
-							?>
-						</p>
-							<?php
-						endif;
+										<p>You can use Prepublish on your account.</p>
+										<?php
+										if ( 0 === $prepublish_enabled ) :
+											?>
+													<p class="siteimprove_prepublish_activation_messages">
+												<?php
+												echo wp_kses(
+													__( 'To enable prepublish for this website click <a href="#" id="siteimprove_enable_prepublish" class="button button-primary">here</a>', 'siteimprove' ),
+													array(
+														'a' => array(
+															'href' => array(),
+															'id' => array(),
+															'class' => array(),
+														),
+													)
+												);
+												?>
+													</p>
+													<?php
+										else :
+											?>
+												<p>
+													<?php
+													echo wp_kses(
+														__( 'Prepublish feature is already enabled for the current website. To use it please go to the preview of any page/post or content that you want to check and click the button <strong>Siteimprove Prepublish Check</strong> located on the top bar of the admin panel', 'siteimprove' ),
+														array(
+															'strong' => array(),
+														)
+													);
+													?>
+												</p>
+													<?php
+										endif;
 				} else {
 					?>
-					<p>
-					<?php
-					esc_html_e( 'You can\'t use Prepublish on your account. Please contact sales team to enable this feature for the current website', 'siteimprove' );
-					?>
-					</p>
-					<?php
+										<p>
+										<?php
+										esc_html_e( 'You can\'t use Prepublish on your account. Please contact sales team to enable this feature for the current website', 'siteimprove' );
+										?>
+										</p>
+										<?php
 				}
 			} else {
 				?>
-				<p>
-				<?php
-				esc_html_e( 'Please provide a valid API Username and API Key before using this feature.', 'siteimprove' );
-				?>
-				</p>
-				<?php
+								<p>
+								<?php
+								esc_html_e( 'Please provide a valid API Username and API Key before using this feature.', 'siteimprove' );
+								?>
+								</p>
+								<?php
 			}
 		}
 
 		if ( 'siteimprove_public_url' === $args['id'] ) {
 			?>
-			<p>
-			<?php
-					esc_html_e( 'Please provide the Public URL for the current site if for any reasons it\'s not the same as the Admin Panel URL. Otherwise you can leave this field empty.' );
-			?>
-			</p>
-			<p>
-			<?php
-					esc_html_e( 'Example: Website Admin Panel is hosted at: http://stg-thewebsite.com but the final Public URL will be http://thewebsite.com', 'siteimprove' );
-			?>
-			</p>
-			<?php
+						<p>
+						<?php
+						esc_html_e( 'Please provide the Public URL for the current site if for any reasons it\'s not the same as the Admin Panel URL. Otherwise you can leave this field empty.' );
+						?>
+						</p>
+						<p>
+						<?php
+						esc_html_e( 'Example: Website Admin Panel is hosted at: http://stg-thewebsite.com but the final Public URL will be http://thewebsite.com', 'siteimprove' );
+						?>
+						</p>
+						<?php
 		}
 
 		if ( 'siteimprove_version_section' === $args['id'] ) {
 			?>
-			<p>
-			<?php
-					esc_html_e( 'A new version of the plugin is now available. Please note it is a work in progress and may update over time.' );
-			?>
-			</p>
-			<?php
+						<p>
+						<?php
+						esc_html_e( 'A new version of the plugin is now available. Please note it is a work in progress and may update over time.' );
+						?>
+						</p>
+						<?php
 		}
 	}
 
@@ -277,8 +277,8 @@ class Siteimprove_Admin_Settings {
 			$is_checked = '';
 		}
 		?>
-		<input type="checkbox" id="siteimprove_disable_new_version_field" name="siteimprove_disable_new_version"  value='1' <?php echo esc_attr( $is_checked ); ?> />
-		<?php
+				<input type="checkbox" id="siteimprove_disable_new_version_field" name="siteimprove_disable_new_version"  value='1' <?php echo esc_attr( $is_checked ); ?> />
+				<?php
 	}
 
 	/**
@@ -290,9 +290,9 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_token_field( $args ) {
 		?>
 
-		<input type="text" id="siteimprove_token_field" name="siteimprove_token" value="<?php echo esc_attr( get_option( 'siteimprove_token' ) ); ?>" maxlength="50" size="50" />
-		<input class="button" id="siteimprove_token_request" type="button" value="<?php echo esc_attr( __( 'Request new token', 'siteimprove' ) ); ?>" />
-		<?php
+				<input type="text" id="siteimprove_token_field" name="siteimprove_token" value="<?php echo esc_attr( get_option( 'siteimprove_token' ) ); ?>" maxlength="50" size="50" />
+				<input class="button" id="siteimprove_token_request" type="button" value="<?php echo esc_attr( __( 'Request new token', 'siteimprove' ) ); ?>" />
+				<?php
 	}
 
 	/**
@@ -303,8 +303,8 @@ class Siteimprove_Admin_Settings {
 	 */
 	public static function siteimprove_public_url_field( $args ) {
 		?>
-		<input type="text" id="siteimprove_public_url_field" name="siteimprove_public_url" value="<?php echo esc_attr( get_option( 'siteimprove_public_url' ) ); ?>"  size="50" />
-		<?php
+				<input type="text" id="siteimprove_public_url_field" name="siteimprove_public_url" value="<?php echo esc_attr( get_option( 'siteimprove_public_url' ) ); ?>"  size="50" />
+				<?php
 	}
 
 	/**
@@ -316,8 +316,8 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_api_username_field( $args ) {
 		?>
 
-		<input type="text" id="siteimprove_api_username_field" name="siteimprove_api_username" value="<?php echo esc_attr( get_option( 'siteimprove_api_username' ) ); ?>" maxlength="50" size="50" />
-		<?php
+				<input type="text" id="siteimprove_api_username_field" name="siteimprove_api_username" value="<?php echo esc_attr( get_option( 'siteimprove_api_username' ) ); ?>" maxlength="50" size="50" />
+				<?php
 	}
 
 	/**
@@ -329,8 +329,8 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_api_key_field( $args ) {
 		?>
 
-		<input type="text" id="siteimprove_api_key_field" name="siteimprove_api_key" value="<?php echo esc_attr( get_option( 'siteimprove_api_key' ) ); ?>" maxlength="50" size="50" />
-		<?php
+				<input type="text" id="siteimprove_api_key_field" name="siteimprove_api_key" value="<?php echo esc_attr( get_option( 'siteimprove_api_key' ) ); ?>" maxlength="50" size="50" />
+				<?php
 	}
 
 	/**
@@ -342,8 +342,8 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_overlayjs_file_field( $args ) {
 		?>
 
-		<input type="text" id="siteimprove_overlayjs_file_field" name="siteimprove_overlayjs_file" value="<?php echo esc_attr( get_option( 'siteimprove_overlayjs_file' ) ); ?>"  size="50" />
-		<?php
+				<input type="text" id="siteimprove_overlayjs_file_field" name="siteimprove_overlayjs_file" value="<?php echo esc_attr( get_option( 'siteimprove_overlayjs_file' ) ); ?>"  size="50" />
+				<?php
 	}
 
 	/**
@@ -357,19 +357,19 @@ class Siteimprove_Admin_Settings {
 
 		settings_errors( 'siteimprove_messages' );
 		?>
-		<div class="wrap">
-			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
-			<form action="options.php" method="post">
-			<?php
-			// Display settings fields.
-			settings_fields( 'siteimprove' );
-			do_settings_sections( 'siteimprove' );
-			// Submit button.
-			submit_button( __( 'Save Settings', 'siteimprove' ) );
-			?>
-			</form>
-		</div>
-			<?php
+				<div class="wrap">
+					<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+					<form action="options.php" method="post">
+					<?php
+					// Display settings fields.
+					settings_fields( 'siteimprove' );
+					do_settings_sections( 'siteimprove' );
+					// Submit button.
+					submit_button( __( 'Save Settings', 'siteimprove' ) );
+					?>
+					</form>
+				</div>
+					<?php
 	}
 
 	/**
@@ -411,10 +411,10 @@ class Siteimprove_Admin_Settings {
 			if (
 				isset( $_POST['siteimprove_api_username'], $_POST['siteimprove_api_key'], $_REQUEST['_wpnonce'] )
 				&& wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'siteimprove-options' )
-				) {
-					$username = sanitize_text_field( wp_unslash( $_POST['siteimprove_api_username'] ) );
-					$key      = sanitize_text_field( wp_unslash( $_POST['siteimprove_api_key'] ) );
-					$result   = self::check_credentials( $username, $key );
+			) {
+				$username = sanitize_text_field( wp_unslash( $_POST['siteimprove_api_username'] ) );
+				$key = sanitize_text_field( wp_unslash( $_POST['siteimprove_api_key'] ) );
+				$result = self::check_credentials( $username, $key );
 				if ( 'false' === $result['status'] ) {
 					// return previous username when error is returned from checking both fields.
 					return $old_value;
@@ -432,7 +432,7 @@ class Siteimprove_Admin_Settings {
 	 */
 	public static function validate_siteimprove_overlayjs_file( $value ) {
 		if ( ! empty( $value ) ) {
-			$old_value        = get_option( 'siteimprove_overlayjs_file' );
+			$old_value = get_option( 'siteimprove_overlayjs_file' );
 			if ( ! preg_match( '/.+\..{2,}/', $value ) ) {
 				add_settings_error( 'siteimprove_messages', 'siteimprove_api_key_error', __( 'Overlay file not saved - Invalid format (please verify if name and extention are correct).', 'siteimprove' ) );
 				if ( ! empty( $old_value ) ) {
@@ -442,8 +442,8 @@ class Siteimprove_Admin_Settings {
 				if (
 					isset( $_POST['siteimprove_overlayjs_file'], $_REQUEST['_wpnonce'] )
 					&& wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'siteimprove-options' )
-					) {
-						return $value;
+				) {
+					return $value;
 				}
 			}
 		}
@@ -468,17 +468,17 @@ class Siteimprove_Admin_Settings {
 				}
 			} else {
 				/*
-				Now if API username and key are set, it's time to test both
-				against the API endpoint to check if it's a valid user/key set
-				and also if the keys correspond to the current website
-				*/
+						Now if API username and key are set, it's time to test both
+						against the API endpoint to check if it's a valid user/key set
+						and also if the keys correspond to the current website
+						*/
 				if (
-				isset( $_POST['siteimprove_api_username'], $_POST['siteimprove_api_key'], $_REQUEST['_wpnonce'] )
-				&& wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'siteimprove-options' )
+					isset( $_POST['siteimprove_api_username'], $_POST['siteimprove_api_key'], $_REQUEST['_wpnonce'] )
+					&& wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'siteimprove-options' )
 				) {
 					$username = sanitize_text_field( wp_unslash( $_POST['siteimprove_api_username'] ) );
-					$key      = sanitize_text_field( wp_unslash( $_POST['siteimprove_api_key'] ) );
-					$result   = self::check_credentials( $username, $key );
+					$key = sanitize_text_field( wp_unslash( $_POST['siteimprove_api_key'] ) );
+					$result = self::check_credentials( $username, $key );
 					if ( 'false' === $result['status'] ) {
 						add_settings_error( 'siteimprove_messages', 'siteimprove_api_credentials_error', $result['error'] );
 						if ( ! empty( $old_value ) ) {
@@ -528,10 +528,10 @@ class Siteimprove_Admin_Settings {
 	public static function make_api_request( $username, $key, $path, $args = array(), $alternate_url = '', $method = 'get' ) {
 		$params = array(
 			'httpversion' => '1.1',
-			'blocking'    => true,
-			'headers'     => array(
+			'blocking' => true,
+			'headers' => array(
 				'Authorization' => 'Basic ' . base64_encode( $username . ':' . $key ),
-				'sslverify'     => false,
+				'sslverify' => false,
 			),
 		);
 		array_merge( $params, $args );
@@ -561,7 +561,7 @@ class Siteimprove_Admin_Settings {
 	public static function check_credentials( $username, $key ) {
 		$return = array(
 			'status' => 'false',
-			'error'  => __( 'Unable to check API Credentials, please try again', 'siteimprove' ),
+			'error' => __( 'Unable to check API Credentials, please try again', 'siteimprove' ),
 		);
 
 		$request = self::make_api_request( $username, $key, '/ping/account' );
@@ -575,7 +575,7 @@ class Siteimprove_Admin_Settings {
 		$request = self::make_api_request( $username, $key, '/sites?page_size=1000' );
 
 		if ( isset( $request['response'] ) && 200 === $request['response']['code'] ) {
-			$results       = json_decode( $request['body'] );
+			$results = json_decode( $request['body'] );
 			$account_sites = $results->items;
 
 			$public_url = get_option( 'siteimprove_public_url' );
@@ -586,7 +586,7 @@ class Siteimprove_Admin_Settings {
 				$site_url = get_site_url();
 			}
 
-			$domain     = wp_parse_url( $site_url, PHP_URL_HOST );
+			$domain = wp_parse_url( $site_url, PHP_URL_HOST );
 			$site_found = false;
 
 			foreach ( $account_sites as $site_key => $site_data ) {
@@ -626,16 +626,16 @@ class Siteimprove_Admin_Settings {
 			}
 		} else {
 			/*
-			TODO: Figure out how to find if the feature is allowed but not enabled yet. For now we
-			are considering that if there are no errors, then we can keep going and suppose it's
-			then possibly allowed to be enabled by the user whenever he wishes to do so.
-			*/
+				 TODO: Figure out how to find if the feature is allowed but not enabled yet. For now we
+				 are considering that if there are no errors, then we can keep going and suppose it's
+				 then possibly allowed to be enabled by the user whenever he wishes to do so.
+				 */
 			update_option( 'siteimprove_prepublish_allowed', 1 );
 
 			/*
-			Now we'll try to see if the prepublish feature is already enabled.
-			If not, then we can show the user a button so he can enable it himself.
-			*/
+				 Now we'll try to see if the prepublish feature is already enabled.
+				 If not, then we can show the user a button so he can enable it himself.
+				 */
 			$results = json_decode( $request['body'] );
 			if ( isset( $results->is_ready ) && true === $results->is_ready ) {
 				update_option( 'siteimprove_prepublish_enabled', 1 );
@@ -652,11 +652,11 @@ class Siteimprove_Admin_Settings {
 	 */
 	public function prepublish_manual_activation() {
 		$siteimprove_api_username = get_option( 'siteimprove_api_username', '' );
-		$siteimprove_api_key      = get_option( 'siteimprove_api_key', '' );
+		$siteimprove_api_key = get_option( 'siteimprove_api_key', '' );
 
 		$return = array(
 			'message' => 'activation_triggered',
-			'result'  => true,
+			'result' => true,
 		);
 
 		$request = self::make_api_request( $siteimprove_api_username, $siteimprove_api_key, '/settings/content_checking', array(), '', 'post' );
@@ -677,11 +677,11 @@ class Siteimprove_Admin_Settings {
 	 */
 	public function check_prepublish_activation() {
 		$siteimprove_api_username = get_option( 'siteimprove_api_username', '' );
-		$siteimprove_api_key      = get_option( 'siteimprove_api_key', '' );
+		$siteimprove_api_key = get_option( 'siteimprove_api_key', '' );
 
 		$return = array(
 			'message' => 'enabled',
-			'result'  => false,
+			'result' => false,
 		);
 
 		$request = self::make_api_request( $siteimprove_api_username, $siteimprove_api_key, '/settings/content_checking', array() );
@@ -702,7 +702,7 @@ class Siteimprove_Admin_Settings {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return;
 		}
-	
+
 		// Check if the nonce is set and is valid.
 		if ( isset( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'siteimprove-options' ) ) {
 			// The nonce is valid, output the token.
@@ -710,7 +710,7 @@ class Siteimprove_Admin_Settings {
 		} else {
 			wp_die();
 		}
-	
+
 		wp_die();
 	}
 }

--- a/siteimprove/admin/partials/class-siteimprove-admin-settings.php
+++ b/siteimprove/admin/partials/class-siteimprove-admin-settings.php
@@ -107,7 +107,7 @@ class Siteimprove_Admin_Settings {
 		);
 
 		// Register a new section in the siteimprove page.
-		if ( isset( $_GET['devmode'] ) && wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'siteimprove-options' ) ) {
+		if ( isset( $_GET['devmode'] ) && ( isset( $_REQUEST['_wpnonce'] ) ) && wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'siteimprove-options' ) ) {
 			add_settings_section(
 				'siteimprove_dev_mode_section',
 				__( 'Dev Mode', 'siteimprove' ),
@@ -183,82 +183,82 @@ class Siteimprove_Admin_Settings {
 			if ( ! empty( $siteimprove_api_key ) ) {
 				if ( 1 === $prepublish_allowed ) {
 					?>
-										<p>You can use Prepublish on your account.</p>
-										<?php
-										if ( 0 === $prepublish_enabled ) :
-											?>
-													<p class="siteimprove_prepublish_activation_messages">
-												<?php
-												echo wp_kses(
-													__( 'To enable prepublish for this website click <a href="#" id="siteimprove_enable_prepublish" class="button button-primary">here</a>', 'siteimprove' ),
-													array(
-														'a' => array(
-															'href' => array(),
-															'id' => array(),
-															'class' => array(),
-														),
-													)
-												);
-												?>
-													</p>
-													<?php
-										else :
-											?>
-												<p>
-													<?php
-													echo wp_kses(
-														__( 'Prepublish feature is already enabled for the current website. To use it please go to the preview of any page/post or content that you want to check and click the button <strong>Siteimprove Prepublish Check</strong> located on the top bar of the admin panel', 'siteimprove' ),
-														array(
-															'strong' => array(),
-														)
-													);
-													?>
-												</p>
-													<?php
-										endif;
+															<p>You can use Prepublish on your account.</p>
+															<?php
+															if ( 0 === $prepublish_enabled ) :
+																?>
+																			<p class="siteimprove_prepublish_activation_messages">
+																		<?php
+																		echo wp_kses(
+																			__( 'To enable prepublish for this website click <a href="#" id="siteimprove_enable_prepublish" class="button button-primary">here</a>', 'siteimprove' ),
+																			array(
+																				'a' => array(
+																					'href' => array(),
+																					'id' => array(),
+																					'class' => array(),
+																				),
+																			)
+																		);
+																		?>
+																			</p>
+																			<?php
+															else :
+																?>
+																		<p>
+																			<?php
+																			echo wp_kses(
+																				__( 'Prepublish feature is already enabled for the current website. To use it please go to the preview of any page/post or content that you want to check and click the button <strong>Siteimprove Prepublish Check</strong> located on the top bar of the admin panel', 'siteimprove' ),
+																				array(
+																					'strong' => array(),
+																				)
+																			);
+																			?>
+																		</p>
+																			<?php
+															endif;
 				} else {
 					?>
-										<p>
-										<?php
-										esc_html_e( 'You can\'t use Prepublish on your account. Please contact sales team to enable this feature for the current website', 'siteimprove' );
-										?>
-										</p>
-										<?php
+															<p>
+															<?php
+															esc_html_e( 'You can\'t use Prepublish on your account. Please contact sales team to enable this feature for the current website', 'siteimprove' );
+															?>
+															</p>
+															<?php
 				}
 			} else {
 				?>
-								<p>
-								<?php
-								esc_html_e( 'Please provide a valid API Username and API Key before using this feature.', 'siteimprove' );
-								?>
-								</p>
-								<?php
+												<p>
+												<?php
+												esc_html_e( 'Please provide a valid API Username and API Key before using this feature.', 'siteimprove' );
+												?>
+												</p>
+												<?php
 			}
 		}
 
 		if ( 'siteimprove_public_url' === $args['id'] ) {
 			?>
-						<p>
-						<?php
-						esc_html_e( 'Please provide the Public URL for the current site if for any reasons it\'s not the same as the Admin Panel URL. Otherwise you can leave this field empty.' );
-						?>
-						</p>
-						<p>
-						<?php
-						esc_html_e( 'Example: Website Admin Panel is hosted at: http://stg-thewebsite.com but the final Public URL will be http://thewebsite.com', 'siteimprove' );
-						?>
-						</p>
-						<?php
+									<p>
+									<?php
+									esc_html_e( 'Please provide the Public URL for the current site if for any reasons it\'s not the same as the Admin Panel URL. Otherwise you can leave this field empty.' );
+									?>
+									</p>
+									<p>
+									<?php
+									esc_html_e( 'Example: Website Admin Panel is hosted at: http://stg-thewebsite.com but the final Public URL will be http://thewebsite.com', 'siteimprove' );
+									?>
+									</p>
+									<?php
 		}
 
 		if ( 'siteimprove_version_section' === $args['id'] ) {
 			?>
-						<p>
-						<?php
-						esc_html_e( 'A new version of the plugin is now available. Please note it is a work in progress and may update over time.' );
-						?>
-						</p>
-						<?php
+									<p>
+									<?php
+									esc_html_e( 'A new version of the plugin is now available. Please note it is a work in progress and may update over time.' );
+									?>
+									</p>
+									<?php
 		}
 	}
 
@@ -277,8 +277,8 @@ class Siteimprove_Admin_Settings {
 			$is_checked = '';
 		}
 		?>
-				<input type="checkbox" id="siteimprove_disable_new_version_field" name="siteimprove_disable_new_version"  value='1' <?php echo esc_attr( $is_checked ); ?> />
-				<?php
+						<input type="checkbox" id="siteimprove_disable_new_version_field" name="siteimprove_disable_new_version"  value='1' <?php echo esc_attr( $is_checked ); ?> />
+						<?php
 	}
 
 	/**
@@ -290,9 +290,9 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_token_field( $args ) {
 		?>
 
-				<input type="text" id="siteimprove_token_field" name="siteimprove_token" value="<?php echo esc_attr( get_option( 'siteimprove_token' ) ); ?>" maxlength="50" size="50" />
-				<input class="button" id="siteimprove_token_request" type="button" value="<?php echo esc_attr( __( 'Request new token', 'siteimprove' ) ); ?>" />
-				<?php
+						<input type="text" id="siteimprove_token_field" name="siteimprove_token" value="<?php echo esc_attr( get_option( 'siteimprove_token' ) ); ?>" maxlength="50" size="50" />
+						<input class="button" id="siteimprove_token_request" type="button" value="<?php echo esc_attr( __( 'Request new token', 'siteimprove' ) ); ?>" />
+						<?php
 	}
 
 	/**
@@ -303,8 +303,8 @@ class Siteimprove_Admin_Settings {
 	 */
 	public static function siteimprove_public_url_field( $args ) {
 		?>
-				<input type="text" id="siteimprove_public_url_field" name="siteimprove_public_url" value="<?php echo esc_attr( get_option( 'siteimprove_public_url' ) ); ?>"  size="50" />
-				<?php
+						<input type="text" id="siteimprove_public_url_field" name="siteimprove_public_url" value="<?php echo esc_attr( get_option( 'siteimprove_public_url' ) ); ?>"  size="50" />
+						<?php
 	}
 
 	/**
@@ -316,8 +316,8 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_api_username_field( $args ) {
 		?>
 
-				<input type="text" id="siteimprove_api_username_field" name="siteimprove_api_username" value="<?php echo esc_attr( get_option( 'siteimprove_api_username' ) ); ?>" maxlength="50" size="50" />
-				<?php
+						<input type="text" id="siteimprove_api_username_field" name="siteimprove_api_username" value="<?php echo esc_attr( get_option( 'siteimprove_api_username' ) ); ?>" maxlength="50" size="50" />
+						<?php
 	}
 
 	/**
@@ -329,8 +329,8 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_api_key_field( $args ) {
 		?>
 
-				<input type="text" id="siteimprove_api_key_field" name="siteimprove_api_key" value="<?php echo esc_attr( get_option( 'siteimprove_api_key' ) ); ?>" maxlength="50" size="50" />
-				<?php
+						<input type="text" id="siteimprove_api_key_field" name="siteimprove_api_key" value="<?php echo esc_attr( get_option( 'siteimprove_api_key' ) ); ?>" maxlength="50" size="50" />
+						<?php
 	}
 
 	/**
@@ -342,8 +342,8 @@ class Siteimprove_Admin_Settings {
 	public static function siteimprove_overlayjs_file_field( $args ) {
 		?>
 
-				<input type="text" id="siteimprove_overlayjs_file_field" name="siteimprove_overlayjs_file" value="<?php echo esc_attr( get_option( 'siteimprove_overlayjs_file' ) ); ?>"  size="50" />
-				<?php
+						<input type="text" id="siteimprove_overlayjs_file_field" name="siteimprove_overlayjs_file" value="<?php echo esc_attr( get_option( 'siteimprove_overlayjs_file' ) ); ?>"  size="50" />
+						<?php
 	}
 
 	/**
@@ -357,19 +357,19 @@ class Siteimprove_Admin_Settings {
 
 		settings_errors( 'siteimprove_messages' );
 		?>
-				<div class="wrap">
-					<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
-					<form action="options.php" method="post">
-					<?php
-					// Display settings fields.
-					settings_fields( 'siteimprove' );
-					do_settings_sections( 'siteimprove' );
-					// Submit button.
-					submit_button( __( 'Save Settings', 'siteimprove' ) );
-					?>
-					</form>
-				</div>
-					<?php
+						<div class="wrap">
+							<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+							<form action="options.php" method="post">
+							<?php
+							// Display settings fields.
+							settings_fields( 'siteimprove' );
+							do_settings_sections( 'siteimprove' );
+							// Submit button.
+							submit_button( __( 'Save Settings', 'siteimprove' ) );
+							?>
+							</form>
+						</div>
+							<?php
 	}
 
 	/**
@@ -468,10 +468,10 @@ class Siteimprove_Admin_Settings {
 				}
 			} else {
 				/*
-						Now if API username and key are set, it's time to test both
-						against the API endpoint to check if it's a valid user/key set
-						and also if the keys correspond to the current website
-						*/
+								Now if API username and key are set, it's time to test both
+								against the API endpoint to check if it's a valid user/key set
+								and also if the keys correspond to the current website
+								*/
 				if (
 					isset( $_POST['siteimprove_api_username'], $_POST['siteimprove_api_key'], $_REQUEST['_wpnonce'] )
 					&& wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'siteimprove-options' )
@@ -626,16 +626,16 @@ class Siteimprove_Admin_Settings {
 			}
 		} else {
 			/*
-				 TODO: Figure out how to find if the feature is allowed but not enabled yet. For now we
-				 are considering that if there are no errors, then we can keep going and suppose it's
-				 then possibly allowed to be enabled by the user whenever he wishes to do so.
-				 */
+						TODO: Figure out how to find if the feature is allowed but not enabled yet. For now we
+						are considering that if there are no errors, then we can keep going and suppose it's
+						then possibly allowed to be enabled by the user whenever he wishes to do so.
+						*/
 			update_option( 'siteimprove_prepublish_allowed', 1 );
 
 			/*
-				 Now we'll try to see if the prepublish feature is already enabled.
-				 If not, then we can show the user a button so he can enable it himself.
-				 */
+						Now we'll try to see if the prepublish feature is already enabled.
+						If not, then we can show the user a button so he can enable it himself.
+						*/
 			$results = json_decode( $request['body'] );
 			if ( isset( $results->is_ready ) && true === $results->is_ready ) {
 				update_option( 'siteimprove_prepublish_enabled', 1 );


### PR DESCRIPTION
### TL;DR
This pull request contains the changes needed to disable the prepublish feature if the plugin user has not set its API credentials on the SI plugin settings page.

### What changed?
A new conditional check is made in order to see if the user has the API key set or not. The credentials are validated when saving the form, so if the credentials aren't valid, they will stay empty. This conditional `has_api_key` is used in the check for if the `prepublish` button should show in the wordpress admin bar or not. It is also used and passed down to the Javascript script that renders the iframe, and conditionally sets the `registerPrepublishCallback` to null if there are no API credentials set.

### How to test?
1. Sign in to the [development environment](https://sicadev.wpengine.com/wp-admin)
2. Check if there are any API credentials set in the SiteImprove settings
3. Open any page/post in preview mode
4. Notice that, if there were no credentials, the top admin bar does not show the Prepublish button
5. Check the iframe Prepublish tab and verify that the button to start the Prepublish doesn't show
6. Add (or remove) the api credentials (opposite as it was on step 2.)
7. Re-do steps 4. and 5. and check for the opposite behavior

### Why make this change?
The motivation behind this change is to validate if the user actually has set valid credentials that give access to the prepublish functionality, removing it if that's not the case, ensuring that users aren't exploiting the plugin to get access to features they don't have.

---
