### PR TITLE
INS-3569 Update WordPress Plugin Marketing Site page

### DIFF
--- a/siteimprove/readme.txt
+++ b/siteimprove/readme.txt
@@ -2,7 +2,7 @@
 Contributors: siteimprove
 Tags: accessibility, analytics, insights, spelling, seo
 Requires at least: 4.7.2
-Tested up to: 6.4.3
+Tested up to: 6.7.1
 Stable tag: 2.0.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
To update the page, we need to update the "Tested up to" version inside the README. The purpose of this change is to avoid the following warning:

![image](https://github.com/user-attachments/assets/9467607b-9c66-4b74-9ea5-19c6432270b9)
