### PR TITLE
INS-3592: Fix double slash in input url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ The code on this repository has to match the WordPress Coding Standards in order
 Every pull request will be checked against WPCS through GitHub Actions.
 
 ## Version History
+### 2.1.1
+* Bugfix - Ignore trailing slash in public url (prevents potential double slash when filtering first path parameter)
+ 
 ### 2.1.0
 * Added - Ignore Path Segments setting to remove specific path segments when building public URLs
 * Enhanced - Public URL functionality to handle complex URL transformations

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -284,7 +284,10 @@ class Siteimprove_Admin {
 
 		// Apply public URL transformation if configured.
 		if ( ! empty( $public_url ) ) {
-			$url = "$public_url$path" . ( isset( $parsed_url['query'] ) ? "?$parsed_url[query]" : '' );
+			$public_url = rtrim( $public_url, '/' );
+			$normalized_path = '/' . ltrim( $path, '/' );
+			$query_string = isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '';
+			$url = $public_url . $normalized_path . $query_string;
 		} else {
 			// If no public URL is set, reconstruct the URL with the filtered path.
 			$scheme = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '';

--- a/siteimprove/readme.txt
+++ b/siteimprove/readme.txt
@@ -87,6 +87,9 @@ Please review whether you have JavaScript turned off in your browser. We use Jav
 
 
 == Changelog ==
+= 2.1.1 =
+* Bugfix - Ignore trailing slash in public url (prevents potential double slash when filtering first path parameter)
+
 = 2.1.0 =
 * Added - Ignore Path Segments setting to remove specific path segments when building public URLs
 * Enhanced - Public URL functionality to handle complex URL transformations


### PR DESCRIPTION
This is fixing an issue with my latest changes to add the "path segment filter" feature. If the public url is set in the settings page with a trailing slash in the url, and we are filtering the first path parameter, the url will end up having double slashes in it, making it invalid.

This PR still does not promote this plugin version as the stable version.