### PR TITLE
PLIA-3972: Load front-end overlay for any user who can edit content

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ The code on this repository has to match the WordPress Coding Standards in order
 Every pull request will be checked against WPCS through GitHub Actions.
 
 ## Version History
+### 2.1.3
+* Bugfix - Load the front-end overlay and Prepublish toolbar action for any user who can edit content (custom roles, multisite super admins), not just a fixed list of role names
+
 ### 2.1.2
 * Updated - Siteimprove logo
 

--- a/siteimprove/admin/class-siteimprove-admin.php
+++ b/siteimprove/admin/class-siteimprove-admin.php
@@ -426,16 +426,7 @@ class Siteimprove_Admin {
 	 */
 	public function siteimprove_wp_head() {
 
-		$user = wp_get_current_user();
-		$allowed_roles = array(
-			'shop_manager',
-			'contributor',
-			'author',
-			'editor',
-			'administrator',
-		);
-
-		if ( array_intersect( $allowed_roles, $user->roles ) ) {
+		if ( current_user_can( 'edit_posts' ) ) {
 			$type = $this->get_current_page_type();
 			switch ( $type ) {
 				case 'front':

--- a/siteimprove/includes/class-siteimprove.php
+++ b/siteimprove/includes/class-siteimprove.php
@@ -60,7 +60,7 @@ class Siteimprove {
 	public function __construct() {
 
 		$this->plugin_name = 'siteimprove';
-		$this->version     = '2.1.2';
+		$this->version     = '2.1.3';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/siteimprove/readme.txt
+++ b/siteimprove/readme.txt
@@ -3,7 +3,7 @@ Contributors: siteimprove
 Tags: accessibility, analytics, insights, spelling, seo
 Requires at least: 4.7.2
 Tested up to: 6.8.1
-Stable tag: 2.1.2
+Stable tag: 2.1.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -87,6 +87,9 @@ Please review whether you have JavaScript turned off in your browser. We use Jav
 
 
 == Changelog ==
+= 2.1.3 =
+* Bugfix - Load the front-end overlay and Prepublish toolbar action for any user who can edit content (custom roles, multisite super admins), not just a fixed list of role names
+
 = 2.1.2 =
 * Updated - Siteimprove logo
 

--- a/siteimprove/siteimprove.php
+++ b/siteimprove/siteimprove.php
@@ -9,7 +9,7 @@
  * Plugin Name:         Siteimprove
  * Plugin URI:          https://www.siteimprove.com/integrations/cms-plugin/wordpress/
  * Description:         Integration with Siteimprove.
- * Version:             2.1.2
+ * Version:             2.1.3
  * Author:              Siteimprove
  * Author URI:          http://www.siteimprove.com/
  * Requires at least:   4.7.2


### PR DESCRIPTION
## Problem

A customer reported that on preview pages the floating Siteimprove overlay never loads, the **Prepublish** toolbar button does nothing (just appends `#` to the URL), and no `siteimprove.js` is present in the DOM — while everything works fine in `wp-admin`.

## Root cause

`siteimprove_wp_head()` was the **only** permission check in the plugin gated on hardcoded role *names*:

```php
$allowed_roles = array( 'shop_manager', 'contributor', 'author', 'editor', 'administrator' );
if ( array_intersect( $allowed_roles, $user->roles ) ) { ... }
```

Every other path (`siteimprove_init()`, the settings screens) uses `current_user_can( ... )`. Users whose role name isn't in that list — custom/renamed roles, or multisite super admins not explicitly assigned a role on a subsite — have editing capabilities but no matching role name, so the overlay JS was never enqueued on the front end. The admin-side paths are capability-gated, which is why they kept working.

This also explains the inert Prepublish button: `add_prepublish_toolbar_item()` renders it without a role check, but its click handler lives in the un-loaded `siteimprove.js`, so clicking just follows `href="#"`.

## Fix

Gate the front-end injection on `current_user_can( 'edit_posts' )`, matching the capability check already used for the identical `'siteimprove_input'` enqueue in `siteimprove_init()`. This covers custom roles, renamed roles, and super admins while still excluding subscribers/visitors.

Version bumped 2.1.2 → 2.1.3 (patch) with changelog entries in `readme.txt` and `README.md`.

## Testing notes

Reproduce with a user who has `edit_posts` but a non-standard role (e.g. a custom role, or a multisite super admin not added to the subsite): before the fix the overlay/Prepublish button is missing on previews; after, both load. Standard roles (administrator/editor/author/contributor/shop_manager) and subscribers are unaffected.